### PR TITLE
공통모듈에 공통객체 정의

### DIFF
--- a/common/domain/build.gradle
+++ b/common/domain/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/common/domain/src/main/java/com/sparta/common/domain/entity/BaseEntity.java
+++ b/common/domain/src/main/java/com/sparta/common/domain/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.sparta.common.domain.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+  @CreatedDate private LocalDateTime createdAt;
+
+  @CreatedBy private String createdBy;
+
+  @LastModifiedDate private LocalDateTime updatedAt;
+
+  @LastModifiedBy private String updatedBy;
+}

--- a/common/domain/src/main/java/com/sparta/common/domain/exception/BusinessException.java
+++ b/common/domain/src/main/java/com/sparta/common/domain/exception/BusinessException.java
@@ -1,0 +1,27 @@
+package com.sparta.common.domain.exception;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BusinessException extends RuntimeException {
+
+  protected String statusName;
+  private final String message;
+
+  public BusinessException(String statusName, String message) {
+    super(message);
+    this.statusName = statusName;
+    this.message = message;
+  }
+
+  public BusinessException(String statusName, String message, Object... args) {
+    super(formattingErrorMessage(message, args));
+    this.statusName = statusName;
+    this.message = formattingErrorMessage(message, args);
+  }
+
+  private static String formattingErrorMessage(String message, Object... objects) {
+    return message.formatted(objects);
+  }
+
+}

--- a/common/domain/src/main/java/com/sparta/common/domain/response/ApiResponse.java
+++ b/common/domain/src/main/java/com/sparta/common/domain/response/ApiResponse.java
@@ -1,0 +1,34 @@
+package com.sparta.common.domain.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ApiResponse<T> {
+  private String statusName;
+  private String message;
+  private T data;
+
+  private ApiResponse(String statusName, String message, T data) {
+    this.statusName = statusName;
+    this.message = message;
+    this.data = data;
+  }
+
+  public static ApiResponse<Void> error(String statusName, String message) {
+    return new ApiResponse<>(statusName, message, null);
+  }
+
+  public static <T> ApiResponse<T> error(String statusName, String message, T data) {
+    return new ApiResponse<>(statusName, message, data);
+  }
+
+  public static <T> ApiResponse<T> created(T data) {
+    return new ApiResponse<>("CREATED", null, data);
+  }
+
+  public static <T> ApiResponse<T> ok(T data) {
+    return new ApiResponse<>("OK", null, data);
+  }
+}


### PR DESCRIPTION
## 🎯 What is this PR
- 모든 서비스에서 사용하는 공통 객체들을 정의하기 위해 common 모듈 정의

## 📄 Changes Made
- 공통 커스텀 예외인 BusinessException
- 공통 응답인 ApiResponse
- Audit 속성을 정의한 BaseEntity

## 🙋🏻‍ Review Point
- HttpStatus 대신에 String값인 statusName을 넣어서 사용하시면 됩니다

## 🔗 Reference
Issue #6 