### PR TITLE
장바구니 상품 추가 API 구현

### DIFF
--- a/service/order/server/build.gradle
+++ b/service/order/server/build.gradle
@@ -29,6 +29,8 @@ ext {
 
 
 dependencies {
+    implementation project(':common:domain')
+    
     implementation 'mysql:mysql-connector-java:8.0.33'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -37,6 +39,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 dependencyManagement {
     imports {

--- a/service/order/server/docs/CartApiTest.http
+++ b/service/order/server/docs/CartApiTest.http
@@ -1,0 +1,15 @@
+@Port=19071
+
+### 장바구니 상품 추가
+POST http://localhost:{{Port}}/api/carts/products
+Content-Type: application/json
+
+{
+  "userId": 123456,
+  "productId": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6g",
+  "productInfoRequest": {
+    "productName": "붕어빵",
+    "price": 3000,
+    "quantity": 3
+  }
+}

--- a/service/order/server/src/main/java/com/sparta/order/server/Cart/application/service/CartService.java
+++ b/service/order/server/src/main/java/com/sparta/order/server/Cart/application/service/CartService.java
@@ -1,0 +1,37 @@
+package com.sparta.order.server.Cart.application.service;
+
+import com.sparta.order.server.Cart.domain.model.CartProduct;
+import com.sparta.order.server.Cart.domain.model.ProductInfo;
+import com.sparta.order.server.Cart.presentation.request.CartRequest;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CartService {
+
+  private final HashOperations<String, String, ProductInfo> cartOps;
+
+  public CartService(RedisTemplate<String, CartProduct> cartTemplate) {
+    this.cartOps = cartTemplate.opsForHash();
+  }
+
+  public void addCart(CartRequest.Add request) {
+    String redisKey = createRedisKey(request.getUserId());
+    ProductInfo existingProductInfo = cartOps.get(redisKey, request.getProductId());
+
+    if (existingProductInfo != null) {
+      existingProductInfo.addQuantity(request.getProductInfoRequest().getQuantity());
+      cartOps.put(redisKey, request.getProductId(),
+          existingProductInfo);
+    } else {
+      cartOps.put(redisKey, request.getProductId(),
+          request.getProductInfoRequest().toEntity());
+    }
+  }
+
+  private String createRedisKey(Long userId) {
+    return "cart:" + userId.toString();
+  }
+
+}

--- a/service/order/server/src/main/java/com/sparta/order/server/Cart/domain/model/CartProduct.java
+++ b/service/order/server/src/main/java/com/sparta/order/server/Cart/domain/model/CartProduct.java
@@ -1,0 +1,16 @@
+package com.sparta.order.server.Cart.domain.model;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CartProduct {
+
+  private UUID productId;
+  private ProductInfo productInfo;
+
+}

--- a/service/order/server/src/main/java/com/sparta/order/server/Cart/domain/model/ProductInfo.java
+++ b/service/order/server/src/main/java/com/sparta/order/server/Cart/domain/model/ProductInfo.java
@@ -1,0 +1,20 @@
+package com.sparta.order.server.Cart.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductInfo {
+
+  private String productName;
+  private int quantity;
+  private int price;
+
+  public void addQuantity(int quantity) {
+    this.quantity += quantity;
+  }
+
+}

--- a/service/order/server/src/main/java/com/sparta/order/server/Cart/infrastructure/configuration/RedisConfig.java
+++ b/service/order/server/src/main/java/com/sparta/order/server/Cart/infrastructure/configuration/RedisConfig.java
@@ -1,0 +1,29 @@
+package com.sparta.order.server.Cart.infrastructure.configuration;
+
+import com.sparta.order.server.Cart.domain.model.CartProduct;
+import com.sparta.order.server.Cart.domain.model.ProductInfo;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+  @Bean
+  public RedisTemplate<String, CartProduct> cartRedisTemplate(
+      RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, CartProduct> template = new RedisTemplate<>();
+    template.setConnectionFactory(connectionFactory);
+
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new Jackson2JsonRedisSerializer<>(CartProduct.class));
+    template.setHashKeySerializer(new StringRedisSerializer());
+    template.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(ProductInfo.class));
+
+    return template;
+  }
+
+}

--- a/service/order/server/src/main/java/com/sparta/order/server/Cart/presentation/controller/CartController.java
+++ b/service/order/server/src/main/java/com/sparta/order/server/Cart/presentation/controller/CartController.java
@@ -1,0 +1,25 @@
+package com.sparta.order.server.Cart.presentation.controller;
+
+import com.sparta.common.domain.response.ApiResponse;
+import com.sparta.order.server.Cart.application.service.CartService;
+import com.sparta.order.server.Cart.presentation.request.CartRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/carts")
+@RequiredArgsConstructor
+public class CartController {
+
+  private final CartService cartService;
+
+  @PostMapping("/products")
+  public ApiResponse<?> addCart(@RequestBody CartRequest.Add request) {
+    cartService.addCart(request);
+    return ApiResponse.created(null);
+  }
+
+}

--- a/service/order/server/src/main/java/com/sparta/order/server/Cart/presentation/request/CartRequest.java
+++ b/service/order/server/src/main/java/com/sparta/order/server/Cart/presentation/request/CartRequest.java
@@ -1,0 +1,38 @@
+package com.sparta.order.server.Cart.presentation.request;
+
+
+import com.sparta.order.server.Cart.domain.model.ProductInfo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CartRequest {
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Add {
+
+    // TODO 인증 인가 구현되면 제외 시키기
+    private Long userId;
+    private String productId;
+    private ProductInfoRequest productInfoRequest;
+
+  }
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class ProductInfoRequest {
+
+    private String productName;
+    private int quantity;
+    private int price;
+
+    public ProductInfo toEntity() {
+      return new ProductInfo(productName, quantity, price);
+    }
+
+  }
+
+}

--- a/service/order/server/src/main/resources/application-local.yml
+++ b/service/order/server/src/main/resources/application-local.yml
@@ -18,6 +18,13 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      username: default
+      password: systempass
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## 🎯 What is this PR

- 장바구니 상품 추가 기능 구현

## 📄 Changes Made

- 주문 모듈 Redis 의존성 및 설정 추가
- 장바구니 상품 추가 API 구현
- 장바구니 상품 추가 http 테스트 작성

## 🙋🏻‍ Review Point

- 장바구니 상품 데이터에 이름, 수량, 1개 상품의 가격 정보를 넣었습니다.
- Redis 호환성을 위해 Redis key, Redis value의 Hash key 값을 String으로 지정하였습니다.
- 사용자 장바구니에 이미 동일한 상품이 존재할 경우 개수를 업데이트하는 방식으로 구현했습니다.
- Product 서비스에 상품 조회 API 구현이 완료되면 상품 검증 로직을 추가할 예정입니다.

## ✅ Test

- [x] http 테스트 작성

![image](https://github.com/user-attachments/assets/fe59dd14-e202-460a-8127-8f37931fc1d4)

![image](https://github.com/user-attachments/assets/7a0ebaf8-c4a2-4881-8a7b-6b7eaab9f9dc)

![image](https://github.com/user-attachments/assets/222d18b3-10fe-4ef4-a9aa-1a1a6317cc4a)



## 🔗 Reference

close #28 