### PR TITLE
장바구니 상품 정보 동기화 내부 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### docker file
+docker-compose.yml
+init.sql

--- a/service/order/server/docs/CartApiTest.http
+++ b/service/order/server/docs/CartApiTest.http
@@ -33,3 +33,6 @@ DELETE http://localhost:{{Port}}/api/carts/products/9b1deb4d-3b7d-4bad-9bdd-2b0d
 
 ### 장바구니 전체 삭제
 DELETE http://localhost:{{Port}}/api/carts/clear?userId=123456
+
+### 장바구니 상품 정보 수정
+PATCH http://localhost:{{Port}}/internal/carts/products/info-update/9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6g

--- a/service/order/server/docs/CartApiTest.http
+++ b/service/order/server/docs/CartApiTest.http
@@ -9,7 +9,7 @@ Content-Type: application/json
   "productId": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6g",
   "productInfoDto": {
     "productName": "붕어빵",
-    "price": -1,
+    "price": 3000,
     "quantity": 3
   }
 }

--- a/service/order/server/src/main/java/com/sparta/order/server/Cart/application/service/CartService.java
+++ b/service/order/server/src/main/java/com/sparta/order/server/Cart/application/service/CartService.java
@@ -7,9 +7,12 @@ import com.sparta.order.server.Cart.exception.CartException;
 import com.sparta.order.server.Cart.presentation.dto.CartDto;
 import com.sparta.order.server.Cart.presentation.dto.CartDto.AddRequest;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,30 +21,34 @@ public class CartService {
   // TODO 상품 단건조회 API 구현 이후 상품 존재여부 검증 로직 추가
   // TODO Redis 트랜잭션 추가
 
-  private final HashOperations<String, String, ProductInfo> cartOps;
+  private final HashOperations<String, String, ProductInfo> userCartOps;
+  private final SetOperations<String, String> cartProductOps;
 
-  public CartService(RedisTemplate<String, CartProduct> cartTemplate) {
-    this.cartOps = cartTemplate.opsForHash();
+  public CartService(RedisTemplate<String, CartProduct> userCartRedisTemplate,
+      StringRedisTemplate cartProductRedisTemplate) {
+    this.userCartOps = userCartRedisTemplate.opsForHash();
+    this.cartProductOps = cartProductRedisTemplate.opsForSet();
   }
 
   public void addCart(AddRequest request) {
-    String redisKey = createRedisKey(request.getUserId());
-    ProductInfo existingProductInfo = cartOps.get(redisKey, request.getProductId());
+    String userCartRedisKey = createUserCartRedisKey(request.getUserId());
+    ProductInfo existingProductInfo = userCartOps.get(userCartRedisKey, request.getProductId());
 
     if (existingProductInfo != null) {
       existingProductInfo.addQuantity(request.getProductInfoDto().getQuantity());
-      cartOps.put(redisKey, request.getProductId(),
+      userCartOps.put(userCartRedisKey, request.getProductId(),
           existingProductInfo);
     } else {
-      cartOps.put(redisKey, request.getProductId(),
+      userCartOps.put(userCartRedisKey, request.getProductId(),
           request.getProductInfoDto().toEntity());
+      addUserInCartProduct(request.getProductId(), request.getUserId().toString());
     }
   }
 
   public Map<String, CartDto.ProductInfoDto> getCart(Long userId) {
-    String redisKey = createRedisKey(userId);
-    validateUserCartExists(redisKey);
-    Map<String, ProductInfo> cartProductInfos = cartOps.entries(redisKey);
+    String userCartRedisKey = createUserCartRedisKey(userId);
+    validateUserCartExists(userCartRedisKey);
+    Map<String, ProductInfo> cartProductInfos = userCartOps.entries(userCartRedisKey);
     Map<String, CartDto.ProductInfoDto> response = cartProductInfos.entrySet().stream()
         .collect(Collectors.toMap(
             Map.Entry::getKey,
@@ -51,13 +58,13 @@ public class CartService {
   }
 
   public void updateCart(CartDto.UpdateRequest request) {
-    String redisKey = createRedisKey(request.getUserId());
-    validateUserCartExists(redisKey);
-    ProductInfo existingProductInfo = cartOps.get(redisKey, request.getProductId());
+    String userCartRedisKey = createUserCartRedisKey(request.getUserId());
+    validateUserCartExists(userCartRedisKey);
+    ProductInfo existingProductInfo = userCartOps.get(userCartRedisKey, request.getProductId());
 
     if (existingProductInfo != null) {
       existingProductInfo.updateQuantity(request.getQuantity());
-      cartOps.put(redisKey, request.getProductId(),
+      userCartOps.put(userCartRedisKey, request.getProductId(),
           existingProductInfo);
     } else {
       throw new CartException(CartErrorCode.PRODUCT_NOT_IN_CART);
@@ -65,31 +72,53 @@ public class CartService {
   }
 
   public void deleteCart(Long userId, String productId) {
-    String redisKey = createRedisKey(userId);
-    validateUserCartExists(redisKey);
-    ProductInfo existingProductInfo = cartOps.get(redisKey, productId);
+    String userCartRedisKey = createUserCartRedisKey(userId);
+    validateUserCartExists(userCartRedisKey);
+    ProductInfo existingProductInfo = userCartOps.get(userCartRedisKey, productId);
 
     if (existingProductInfo != null) {
-      cartOps.delete(redisKey, productId);
+      userCartOps.delete(userCartRedisKey, productId);
     } else {
       throw new CartException(CartErrorCode.PRODUCT_NOT_IN_CART);
     }
+    deleteUserInCartProduct(productId, userId.toString());
+  }
+
+  public void updateCartInfo(String productId) {
   }
 
   public void clearCart(Long userId) {
-    String redisKey = createRedisKey(userId);
-    validateUserCartExists(redisKey);
-    cartOps.keys(redisKey).forEach(key -> cartOps.delete(redisKey, key));
+    String userCartRedisKey = createUserCartRedisKey(userId);
+    validateUserCartExists(userCartRedisKey);
+
+    Set<String> productIds = userCartOps.keys(userCartRedisKey);
+    productIds.forEach(key -> userCartOps.delete(userCartRedisKey, key));
+    productIds.forEach(key -> deleteUserInCartProduct(key, userId.toString()));
   }
 
-  private String createRedisKey(Long userId) {
-    return "cart:" + userId.toString();
+  private void addUserInCartProduct(String productId, String userId) {
+    String cartProductRedisKey = createCartProductRedisKey(productId);
+    cartProductOps.add(cartProductRedisKey, userId);
   }
 
-  private void validateUserCartExists(String redisKey) {
-    if (cartOps.entries(redisKey).isEmpty()) {
+  private void deleteUserInCartProduct(String productId, String userId) {
+    String cartProductRedisKey = createCartProductRedisKey(productId);
+    cartProductOps.remove(cartProductRedisKey, userId);
+  }
+
+  private void validateUserCartExists(String userCartRedisKey) {
+    if (userCartOps.entries(userCartRedisKey).isEmpty()) {
       throw new CartException(CartErrorCode.CART_NOT_FOUND);
     }
   }
+
+  private String createUserCartRedisKey(Long userId) {
+    return "cart:" + userId.toString();
+  }
+
+  private String createCartProductRedisKey(String productId) {
+    return "cart:product:" + productId + ":users";
+  }
+
 
 }

--- a/service/order/server/src/main/java/com/sparta/order/server/Cart/infrastructure/configuration/RedisConfig.java
+++ b/service/order/server/src/main/java/com/sparta/order/server/Cart/infrastructure/configuration/RedisConfig.java
@@ -13,7 +13,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RedisConfig {
 
   @Bean
-  public RedisTemplate<String, CartProduct> cartRedisTemplate(
+  public RedisTemplate<String, CartProduct> userCartRedisTemplate(
       RedisConnectionFactory connectionFactory) {
     RedisTemplate<String, CartProduct> template = new RedisTemplate<>();
     template.setConnectionFactory(connectionFactory);

--- a/service/order/server/src/main/java/com/sparta/order/server/Cart/presentation/controller/CartInternalController.java
+++ b/service/order/server/src/main/java/com/sparta/order/server/Cart/presentation/controller/CartInternalController.java
@@ -1,5 +1,6 @@
 package com.sparta.order.server.Cart.presentation.controller;
 
+import com.sparta.common.domain.response.ApiResponse;
 import com.sparta.order.server.Cart.application.service.CartService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -15,8 +16,9 @@ public class CartInternalController {
   private final CartService cartService;
 
   @PatchMapping("/products/info-update/{productId}")
-  public void updateCartInfo(@PathVariable(name = "productId") String productId) {
+  public ApiResponse<?> updateCartInfo(@PathVariable(name = "productId") String productId) {
     cartService.updateCartInfo(productId);
+    return ApiResponse.ok(null);
   }
 
 }

--- a/service/order/server/src/main/java/com/sparta/order/server/Cart/presentation/controller/CartInternalController.java
+++ b/service/order/server/src/main/java/com/sparta/order/server/Cart/presentation/controller/CartInternalController.java
@@ -1,0 +1,22 @@
+package com.sparta.order.server.Cart.presentation.controller;
+
+import com.sparta.order.server.Cart.application.service.CartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/carts")
+public class CartInternalController {
+
+  private final CartService cartService;
+
+  @PatchMapping("/products/info-update/{productId}")
+  public void updateCartInfo(@PathVariable(name = "productId") String productId) {
+    cartService.updateCartInfo(productId);
+  }
+
+}


### PR DESCRIPTION
## 🎯 What is this PR

- 장바구니 상품 정보 변경 내부 API 구현

## 📄 Changes Made

- 장바구니에 상품 추가 시 해당 상품을 장바구니에 담은 사용자 ID 별도 저장
- 장바구니에 상품 삭제 시 별도로 저장했던 사용자 ID 삭제
- 장바구니 상품 변경 내부 API 구현

## 🙋🏻‍ Review Point
- 상품 단건 조회 API 구현 이후에 관련된 로직 수정이 필요합니다.
- 상품마다 `장바구니에 해당 상품을 담은 사용자 ID`를 저장하여 상품 정보 변경을 동기화하고 있는데 해당 방법이 괜찮은지 궁금합니다.
- 만약 괜찮지 않다면 다른 기능들 구현 후, 장바구니를 DB에 저장하여 캐싱하는 방식으로 리팩토링 해야할 것 같습니다.

## ✅ Test

- [x] http 테스트 작성

![image](https://github.com/user-attachments/assets/cae2ce0e-9507-4eaa-a81c-625286ed646f)


## 🔗 Reference

- Issue #45 