### PR TITLE
상품 조회 API 구현 및 상품 컬럼 추가

### DIFF
--- a/service/product/product_dto/src/main/java/com/sparta/product_dto/ProductDto.java
+++ b/service/product/product_dto/src/main/java/com/sparta/product_dto/ProductDto.java
@@ -1,0 +1,40 @@
+package com.sparta.product_dto;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProductDto {
+  private UUID productId;
+  private String productName;
+  private BigDecimal originalPrice;
+  private BigDecimal discountedPrice;
+  private Double discountPercent;
+  private int stock;
+  private boolean soldout;
+  private boolean isCoupon;
+
+  @Builder
+  private ProductDto(
+      UUID productId,
+      String productName,
+      BigDecimal originalPrice,
+      BigDecimal discountedPrice,
+      Double discountPercent,
+      int stock,
+      boolean soldout,
+      boolean isCoupon) {
+    this.productId = productId;
+    this.productName = productName;
+    this.originalPrice = originalPrice;
+    this.discountedPrice = discountedPrice;
+    this.discountPercent = discountPercent;
+    this.stock = stock;
+    this.soldout = soldout;
+    this.isCoupon = isCoupon;
+  }
+}

--- a/service/product/product_dto/src/main/java/com/sparta/product_dto/ProductDto.java
+++ b/service/product/product_dto/src/main/java/com/sparta/product_dto/ProductDto.java
@@ -1,6 +1,7 @@
 package com.sparta.product_dto;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,8 +16,7 @@ public class ProductDto {
   private BigDecimal discountedPrice;
   private Double discountPercent;
   private int stock;
-  private boolean soldout;
-  private boolean isCoupon;
+  private List<String> tags;
 
   @Builder
   private ProductDto(
@@ -26,7 +26,7 @@ public class ProductDto {
       BigDecimal discountedPrice,
       Double discountPercent,
       int stock,
-      boolean soldout,
+      List<String> tags,
       boolean isCoupon) {
     this.productId = productId;
     this.productName = productName;
@@ -34,7 +34,6 @@ public class ProductDto {
     this.discountedPrice = discountedPrice;
     this.discountPercent = discountPercent;
     this.stock = stock;
-    this.soldout = soldout;
-    this.isCoupon = isCoupon;
+    this.tags = tags;
   }
 }

--- a/service/product/product_dto/src/main/java/com/sparta/product_dto/ProductReadRequest.java
+++ b/service/product/product_dto/src/main/java/com/sparta/product_dto/ProductReadRequest.java
@@ -1,0 +1,5 @@
+package com.sparta.product_dto;
+
+import java.util.List;
+
+public record ProductReadRequest(List<String> productIds) {}

--- a/service/product/product_server/src/main/java/com/sparta/product/application/ProductMapper.java
+++ b/service/product/product_server/src/main/java/com/sparta/product/application/ProductMapper.java
@@ -3,8 +3,21 @@ package com.sparta.product.application;
 import com.sparta.product.domain.model.Product;
 import com.sparta.product.presentation.request.ProductCreateRequest;
 import com.sparta.product.presentation.request.ProductUpdateRequest;
+import com.sparta.product_dto.ProductDto;
 
 public class ProductMapper {
+
+  public static ProductDto fromEntity(Product product) {
+    return ProductDto.builder()
+        .productId(product.getProductId())
+        .productName(product.getProductName())
+        .discountPercent(product.getDiscountPercent())
+        .discountedPrice(product.getDiscountedPrice())
+        .soldout(product.isSoldout())
+        .isCoupon(product.isCoupon())
+        .build();
+  }
+
   public static Product toEntity(ProductCreateRequest request) {
     return Product.builder()
         .categoryId(request.categoryId())

--- a/service/product/product_server/src/main/java/com/sparta/product/application/ProductMapper.java
+++ b/service/product/product_server/src/main/java/com/sparta/product/application/ProductMapper.java
@@ -13,8 +13,8 @@ public class ProductMapper {
         .productName(product.getProductName())
         .discountPercent(product.getDiscountPercent())
         .discountedPrice(product.getDiscountedPrice())
-        .soldout(product.isSoldout())
-        .isCoupon(product.isCoupon())
+        .stock(product.getStock())
+        .tags(product.getTags())
         .build();
   }
 
@@ -22,6 +22,9 @@ public class ProductMapper {
     return Product.builder()
         .categoryId(request.categoryId())
         .productName(request.productName())
+        .brandName(request.brandName())
+        .mainColor(request.mainColor())
+        .size(request.size())
         .description(request.description())
         .originalPrice(request.originalPrice())
         .discountPercent(request.discountPercent())
@@ -29,7 +32,7 @@ public class ProductMapper {
         .detailImgUrl(request.detailImgUrl())
         .stock(request.stock())
         .limitCountPerUser(request.limitCountPerUser())
-        .isCoupon(request.isCoupon())
+        .tags(request.tags())
         .build();
   }
 
@@ -37,6 +40,9 @@ public class ProductMapper {
     existingProduct.updateProduct(
         request.categoryId(),
         request.productName(),
+        request.brandName(),
+        request.mainColor(),
+        request.size(),
         request.originalPrice(),
         request.discountPercent(),
         request.stock(),
@@ -44,7 +50,7 @@ public class ProductMapper {
         request.thumbnailImgUrl(),
         request.detailImgUrl(),
         request.limitCountPerUser(),
-        request.isPublic(),
-        request.isCoupon());
+        request.tags(),
+        request.isPublic());
   }
 }

--- a/service/product/product_server/src/main/java/com/sparta/product/application/ProductService.java
+++ b/service/product/product_server/src/main/java/com/sparta/product/application/ProductService.java
@@ -7,7 +7,10 @@ import com.sparta.product.presentation.exception.ProductServerException;
 import com.sparta.product.presentation.request.ProductCreateRequest;
 import com.sparta.product.presentation.request.ProductUpdateRequest;
 import com.sparta.product.presentation.response.ProductResponse;
+import com.sparta.product_dto.ProductDto;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,6 +54,13 @@ public class ProductService {
 
   public ProductResponse getProduct(UUID productId) {
     return ProductResponse.fromEntity(getSavedProduct(productId));
+  }
+
+  public List<ProductDto> getProductList(List<String> productIds) {
+    return productIds.stream()
+        .map(productId -> getSavedProduct(UUID.fromString(productId)))
+        .map(ProductMapper::fromEntity)
+        .collect(Collectors.toList());
   }
 
   private Product getSavedProduct(UUID productId) {

--- a/service/product/product_server/src/main/java/com/sparta/product/application/ProductService.java
+++ b/service/product/product_server/src/main/java/com/sparta/product/application/ProductService.java
@@ -49,6 +49,10 @@ public class ProductService {
     return ProductResponse.fromEntity(product);
   }
 
+  public ProductResponse getProduct(UUID productId) {
+    return ProductResponse.fromEntity(getSavedProduct(productId));
+  }
+
   private Product getSavedProduct(UUID productId) {
     return productRepository
         .findByProductIdAndIsDeletedFalse(productId)

--- a/service/product/product_server/src/main/java/com/sparta/product/domain/model/Product.java
+++ b/service/product/product_server/src/main/java/com/sparta/product/domain/model/Product.java
@@ -2,6 +2,7 @@ package com.sparta.product.domain.model;
 
 import com.sparta.common.domain.entity.BaseEntity;
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,34 +14,32 @@ import org.springframework.data.domain.Persistable;
 
 @Table("P_PRODUCT")
 @Getter
-
 public class Product extends BaseEntity implements Persistable {
   @PrimaryKey private UUID productId = UUID.randomUUID();
-
   @Column public Long categoryId;
-
   @Column public String productName;
-
-  @Column public BigDecimal originalPrice;
-
-  @Column public BigDecimal discountedPrice;
-
-  @Column public Double discountPercent;
-
-  @Column public int stock;
-
+  @Column public String brandName;
+  @Column public String mainColor;
+  @Column public String size;
   @Column public String description;
 
-  @Column public String thumbnailImgUrl;
+  @Column public BigDecimal originalPrice;
+  @Column public BigDecimal discountedPrice;
+  @Column public Double discountPercent;
+  @Column public int stock;
 
+  @Column public String thumbnailImgUrl;
   @Column public String detailImgUrl;
 
   @Column public int limitCountPerUser = 0;
-  @Column public double averageRating = 0.0; // TODO :: 리뷰가 등록될떄마다 평균평점 계산
+  @Column public double averageRating = 0.0;
+  @Column public long reviewCount = 0;
+  @Column public long salesCount = 0;
+
   @Column public boolean isPublic = true;
   @Column public boolean soldout = false;
   @Column public boolean isDeleted = false;
-  @Column public boolean isCoupon;
+  @Column public List<String> tags;
   @Transient private boolean isNew = false;
 
   @Override
@@ -58,6 +57,9 @@ public class Product extends BaseEntity implements Persistable {
   private Product(
       Long categoryId,
       String productName,
+      String brandName,
+      String mainColor,
+      String size,
       BigDecimal originalPrice,
       Double discountPercent,
       int stock,
@@ -65,9 +67,12 @@ public class Product extends BaseEntity implements Persistable {
       String thumbnailImgUrl,
       String detailImgUrl,
       int limitCountPerUser,
-      boolean isCoupon) {
+      List<String> tags) {
     this.categoryId = categoryId;
     this.productName = productName;
+    this.brandName = brandName;
+    this.mainColor = mainColor;
+    this.size = size;
     this.originalPrice = originalPrice;
     this.discountPercent = discountPercent;
     applyDiscount(discountPercent);
@@ -76,12 +81,15 @@ public class Product extends BaseEntity implements Persistable {
     this.thumbnailImgUrl = thumbnailImgUrl;
     this.detailImgUrl = detailImgUrl;
     this.limitCountPerUser = limitCountPerUser;
-    this.isCoupon = isCoupon;
+    this.tags = tags;
   }
 
   public void updateProduct(
       Long categoryId,
       String productName,
+      String brandName,
+      String mainColor,
+      String size,
       BigDecimal originalPrice,
       Double discountPercent,
       Integer stock,
@@ -89,10 +97,13 @@ public class Product extends BaseEntity implements Persistable {
       String thumbnailImgUrl,
       String detailImgUrl,
       Integer limitCountPerUser,
-      boolean isPublic,
-      boolean isCoupon) {
+      List<String> tags,
+      boolean isPublic) {
     this.categoryId = categoryId;
     this.productName = productName;
+    this.brandName = brandName;
+    this.mainColor = mainColor;
+    this.size = size;
     this.originalPrice = originalPrice;
     this.discountPercent = discountPercent;
     applyDiscount(discountPercent);
@@ -100,9 +111,9 @@ public class Product extends BaseEntity implements Persistable {
     this.description = description;
     this.thumbnailImgUrl = thumbnailImgUrl;
     this.detailImgUrl = detailImgUrl;
+    this.tags = tags;
     this.limitCountPerUser = limitCountPerUser;
     this.isPublic = isPublic;
-    this.isCoupon = isCoupon;
   }
 
   public UUID getProductId() {

--- a/service/product/product_server/src/main/java/com/sparta/product/infrastructure/elasticsearch/dto/ProductSearchDto.java
+++ b/service/product/product_server/src/main/java/com/sparta/product/infrastructure/elasticsearch/dto/ProductSearchDto.java
@@ -2,6 +2,7 @@ package com.sparta.product.infrastructure.elasticsearch.dto;
 
 import com.sparta.product.presentation.response.ProductResponse;
 import java.math.BigDecimal;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,6 +16,9 @@ public class ProductSearchDto {
   @Id private String productId;
   private Long categoryId;
   private String productName;
+  private String brandName;
+  private String mainColor;
+  private String size;
   private BigDecimal originalPrice;
   private BigDecimal discountedPrice;
   private Double discountPercent;
@@ -24,14 +28,17 @@ public class ProductSearchDto {
   private double averageRating;
   private boolean isPublic;
   private boolean soldout;
+  private List<String> tags;
   private boolean isDeleted;
-  private boolean isCoupon;
 
   @Builder
   private ProductSearchDto(
       String productId,
       Long categoryId,
       String productName,
+      String brandName,
+      String mainColor,
+      String size,
       BigDecimal originalPrice,
       BigDecimal discountedPrice,
       Double discountPercent,
@@ -42,10 +49,13 @@ public class ProductSearchDto {
       boolean isPublic,
       boolean soldout,
       boolean isDeleted,
-      boolean isCoupon) {
+      List<String> tags) {
     this.productId = productId;
     this.categoryId = categoryId;
     this.productName = productName;
+    this.brandName = brandName;
+    this.mainColor = mainColor;
+    this.size = size;
     this.originalPrice = originalPrice;
     this.discountedPrice = discountedPrice;
     this.discountPercent = discountPercent;
@@ -56,7 +66,7 @@ public class ProductSearchDto {
     this.isPublic = isPublic;
     this.soldout = soldout;
     this.isDeleted = isDeleted;
-    this.isCoupon = isCoupon;
+    this.tags = tags;
   }
 
   public static ProductSearchDto toDto(ProductResponse product) {
@@ -64,6 +74,9 @@ public class ProductSearchDto {
         .productId(product.getProductId())
         .categoryId(product.getCategoryId())
         .productName(product.getProductName())
+        .brandName(product.getBrandName())
+        .mainColor(product.getMainColor())
+        .size(product.getSize())
         .originalPrice(product.getOriginalPrice())
         .discountedPrice(product.getDiscountedPrice())
         .discountPercent(product.getDiscountPercent())
@@ -73,7 +86,6 @@ public class ProductSearchDto {
         .averageRating(product.getAverageRating())
         .isPublic(product.isPublic())
         .isDeleted(product.isDeleted())
-        .isCoupon(product.isCoupon())
         .soldout(product.isSoldout())
         .build();
   }

--- a/service/product/product_server/src/main/java/com/sparta/product/presentation/controller/ProductController.java
+++ b/service/product/product_server/src/main/java/com/sparta/product/presentation/controller/ProductController.java
@@ -2,6 +2,7 @@ package com.sparta.product.presentation.controller;
 
 import com.sparta.common.domain.response.ApiResponse;
 import com.sparta.product.application.ProductFacadeService;
+import com.sparta.product.application.ProductService;
 import com.sparta.product.presentation.request.ProductCreateRequest;
 import com.sparta.product.presentation.request.ProductUpdateRequest;
 import com.sparta.product.presentation.response.ProductResponse;
@@ -10,6 +11,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class ProductController {
   private final ProductFacadeService facadeService;
+  private final ProductService productService;
 
   @PostMapping
   public ApiResponse<String> createProduct(@RequestBody ProductCreateRequest request) {
@@ -44,5 +47,11 @@ public class ProductController {
   @DeleteMapping("/{productId}")
   public ApiResponse<Boolean> deleteProduct(@PathVariable("productId") @NotNull UUID productId) {
     return ApiResponse.ok(facadeService.deleteProduct(productId));
+  }
+
+  @GetMapping("/{productId}")
+  public ApiResponse<ProductResponse> getProduct(
+      @PathVariable("productId") @NotNull UUID productId) {
+    return ApiResponse.ok(productService.getProduct(productId));
   }
 }

--- a/service/product/product_server/src/main/java/com/sparta/product/presentation/controller/ProductInternalController.java
+++ b/service/product/product_server/src/main/java/com/sparta/product/presentation/controller/ProductInternalController.java
@@ -1,0 +1,23 @@
+package com.sparta.product.presentation.controller;
+
+import com.sparta.product.application.ProductService;
+import com.sparta.product_dto.ProductDto;
+import com.sparta.product_dto.ProductReadRequest;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/products")
+public class ProductInternalController {
+  private final ProductService productService;
+
+  @GetMapping
+  public List<ProductDto> getProductList(@RequestBody ProductReadRequest request) {
+    return productService.getProductList(request.productIds());
+  }
+}

--- a/service/product/product_server/src/main/java/com/sparta/product/presentation/request/ProductCreateRequest.java
+++ b/service/product/product_server/src/main/java/com/sparta/product/presentation/request/ProductCreateRequest.java
@@ -3,10 +3,14 @@ package com.sparta.product.presentation.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
+import java.util.List;
 
 public record ProductCreateRequest(
     @NotNull(message = "카테고리아이디는 필수입니다") Long categoryId,
     @NotBlank(message = "상품이름은 필수입니다") String productName,
+    @NotBlank(message = "브랜드이름은 필수입니다") String brandName,
+    @NotBlank(message = "메인컬러는 필수입니다") String mainColor,
+    @NotBlank(message = "상품사이즈는 필수입니다") String size,
     @NotNull(message = "상품가격은 필수입니다") BigDecimal originalPrice,
     Double discountPercent,
     @NotNull(message = "상품재고수량은 필수입니다") Integer stock,
@@ -14,4 +18,4 @@ public record ProductCreateRequest(
     @NotBlank(message = "썸네일이미지주소는 필수입니다") String thumbnailImgUrl,
     @NotBlank(message = "상세이미지주소는 필수입니다") String detailImgUrl,
     @NotNull(message = "상품이름은 필수입니다") Integer limitCountPerUser,
-    @NotNull(message = "쿠폰적용여부는 필수입니다") Boolean isCoupon) {}
+    List<String> tags) {}

--- a/service/product/product_server/src/main/java/com/sparta/product/presentation/request/ProductUpdateRequest.java
+++ b/service/product/product_server/src/main/java/com/sparta/product/presentation/request/ProductUpdateRequest.java
@@ -3,12 +3,16 @@ package com.sparta.product.presentation.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 
 public record ProductUpdateRequest(
     @NotNull(message = "상품아이디는 필수입니다") UUID productId,
     @NotNull(message = "카테고리아이디는 필수입니다") Long categoryId,
     @NotBlank(message = "상품이름은 필수입니다") String productName,
+    @NotBlank(message = "브랜드이름은 필수입니다") String brandName,
+    @NotBlank(message = "메인컬러는 필수입니다") String mainColor,
+    @NotBlank(message = "상품사이즈는 필수입니다") String size,
     @NotNull(message = "상품가격은 필수입니다") BigDecimal originalPrice,
     Double discountPercent,
     @NotNull(message = "상품재고수량은 필수입니다") Integer stock,
@@ -17,4 +21,4 @@ public record ProductUpdateRequest(
     @NotBlank(message = "상세이미지주소는 필수입니다") String detailImgUrl,
     @NotNull(message = "상품이름은 필수입니다") Integer limitCountPerUser,
     @NotNull(message = "공개여부는 필수입니다") Boolean isPublic,
-    @NotNull(message = "쿠폰적용여부는 필수입니다") Boolean isCoupon) {}
+    List<String> tags) {}

--- a/service/product/product_server/src/main/java/com/sparta/product/presentation/response/ProductResponse.java
+++ b/service/product/product_server/src/main/java/com/sparta/product/presentation/response/ProductResponse.java
@@ -2,6 +2,7 @@ package com.sparta.product.presentation.response;
 
 import com.sparta.product.domain.model.Product;
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +13,9 @@ import lombok.NoArgsConstructor;
 public class ProductResponse {
   private String productId;
   private Long categoryId;
+  private String brandName;
+  private String mainColor;
+  private String size;
   private String productName;
   private BigDecimal originalPrice;
   private BigDecimal discountedPrice;
@@ -22,16 +26,21 @@ public class ProductResponse {
   private String detailImgUrl;
   private int limitCountPerUser;
   private double averageRating;
+  private long reviewCount;
+  private long salesCount;
   private boolean isPublic;
   private boolean soldout;
   private boolean isDeleted;
-  private boolean isCoupon;
+  private List<String> tags;
 
   @Builder
   private ProductResponse(
       UUID productId,
       Long categoryId,
       String productName,
+      String brandName,
+      String mainColor,
+      String size,
       BigDecimal originalPrice,
       BigDecimal discountedPrice,
       Double discountPercent,
@@ -41,13 +50,18 @@ public class ProductResponse {
       String detailImgUrl,
       int limitCountPerUser,
       double averageRating,
+      long reviewCount,
+      long salesCount,
       boolean isPublic,
       boolean soldout,
       boolean isDeleted,
-      boolean isCoupon) {
+      List<String> tags) {
     this.productId = productId.toString();
     this.categoryId = categoryId;
     this.productName = productName;
+    this.brandName = brandName;
+    this.mainColor = mainColor;
+    this.size = size;
     this.originalPrice = originalPrice;
     this.discountedPrice = discountedPrice;
     this.discountPercent = discountPercent;
@@ -57,30 +71,37 @@ public class ProductResponse {
     this.detailImgUrl = detailImgUrl;
     this.limitCountPerUser = limitCountPerUser;
     this.averageRating = averageRating;
+    this.reviewCount = reviewCount;
+    this.salesCount = salesCount;
     this.isPublic = isPublic;
     this.soldout = soldout;
     this.isDeleted = isDeleted;
-    this.isCoupon = isCoupon;
+    this.tags = tags;
   }
 
   public static ProductResponse fromEntity(Product product) {
     return ProductResponse.builder()
         .productId(product.getProductId())
-        .categoryId(product.categoryId)
-        .productName(product.productName)
-        .description(product.description)
-        .thumbnailImgUrl(product.thumbnailImgUrl)
-        .detailImgUrl(product.detailImgUrl)
-        .originalPrice(product.originalPrice)
-        .discountPercent(product.discountPercent)
-        .discountedPrice(product.discountedPrice)
-        .stock(product.stock)
-        .limitCountPerUser(product.limitCountPerUser)
-        .averageRating(product.averageRating)
-        .isCoupon(product.isCoupon)
-        .isDeleted(product.isDeleted)
-        .isPublic(product.isPublic)
-        .soldout(product.soldout)
+        .categoryId(product.getCategoryId())
+        .productName(product.getProductName())
+        .brandName(product.getBrandName())
+        .mainColor(product.getMainColor())
+        .size(product.getSize())
+        .description(product.getDescription())
+        .thumbnailImgUrl(product.getThumbnailImgUrl())
+        .detailImgUrl(product.getDetailImgUrl())
+        .originalPrice(product.getOriginalPrice())
+        .discountPercent(product.getDiscountPercent())
+        .discountedPrice(product.getDiscountedPrice())
+        .stock(product.getStock())
+        .limitCountPerUser(product.getLimitCountPerUser())
+        .reviewCount(product.getReviewCount())
+        .salesCount(product.getSalesCount())
+        .averageRating(product.getAverageRating())
+        .isDeleted(product.isDeleted())
+        .isPublic(product.isPublic())
+        .soldout(product.isSoldout())
+        .tags(product.getTags())
         .build();
   }
 }

--- a/service/product/product_server/src/test/java/com/sparta/product/ProductServerApplicationTests.java
+++ b/service/product/product_server/src/test/java/com/sparta/product/ProductServerApplicationTests.java
@@ -1,9 +1,8 @@
 package com.sparta.product;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+//@SpringBootTest
 class ProductServerApplicationTests {
 
   @Test


### PR DESCRIPTION
## 🎯 What is this PR
- 상품 단일조회 API (by Cassandra)
- 주문서버에서 요청하는 상품목록조회 API(by Cassandra)
- 상품 엔티티에 필터링 관련 컬럼들 추가(브랜드이름, 메인컬러, 사이즈, 태그)
- 상품 엔티티에 정렬 관련 컬럼들 추가(판매카운트, 리뷰카운트)

## 📄 Changes Made
- 상품 엔티티에 isCoupon 삭제하고 List<String> tags 컬럼으로 추가 
- 주문서버에서 삭제 productId 요청시 NOT_FOUND_PRODUCT 에러 즉각적으로 발생 

## 🙋🏻‍ Review Point
- 태그 종류로는 "COUPON", "EXPRESS_DELIVERY", "FREE_SHIPPING", "DISCOUNT", "NEW", "1+1", "RECOMMEND"가 있음
- 추후 재고감소 로직에 판매카운트 증가 로직 추가, 리뷰 등록때 리뷰카운트 증가 로직 추가 필요함 

## ✅ Test
> 상품단일조회(상세조회)
![image](https://github.com/user-attachments/assets/73abedd0-45d0-406e-a884-9ca58d399320)


> 내부API 상품목록조회 
![스크린샷 2024-10-07 오후 6 26 09](https://github.com/user-attachments/assets/197a2a64-b387-447b-bc73-98ed809e4730)

## 🔗 Reference

Issue #59 