### PR TITLE
배송지 관련 기능 구현

### DIFF
--- a/service/user/server/src/main/java/com/sparta/user/application/dto/AddressResponse.java
+++ b/service/user/server/src/main/java/com/sparta/user/application/dto/AddressResponse.java
@@ -1,0 +1,41 @@
+package com.sparta.user.application.dto;
+
+import com.sparta.user.domain.model.Address;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AddressResponse {
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class Get {
+
+    private Long id;
+    private Long userId;
+    private String alias;
+    private String recipient;
+    private String phoneNumber;
+    private String zipcode;
+    private String address;
+    private Boolean isDefault;
+
+    public static AddressResponse.Get of(Address address) {
+      return Get.builder()
+          .id(address.getId())
+          .userId(address.getUser().getId())
+          .alias(address.getAlias())
+          .recipient(address.getRecipient())
+          .phoneNumber(address.getPhoneNumber())
+          .zipcode(address.getZipcode())
+          .address(address.getAddress())
+          .isDefault(address.getIsDefault())
+          .build();
+    }
+
+  }
+
+}

--- a/service/user/server/src/main/java/com/sparta/user/application/service/AddressService.java
+++ b/service/user/server/src/main/java/com/sparta/user/application/service/AddressService.java
@@ -80,4 +80,15 @@ public class AddressService {
     address.update(request);
   }
 
+  @Transactional
+  public void deleteAddress(Long userId, Long addressId) {
+    userRepository
+        .findById(userId)
+        .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+    Address address = addressRepository
+        .findById(addressId)
+        .orElseThrow(() -> new UserException(UserErrorCode.ADDRESS_NOT_FOUND));
+    addressRepository.delete(address);
+  }
+
 }

--- a/service/user/server/src/main/java/com/sparta/user/application/service/AddressService.java
+++ b/service/user/server/src/main/java/com/sparta/user/application/service/AddressService.java
@@ -11,11 +11,13 @@ import com.sparta.user.domain.repository.UserRepository;
 import com.sparta.user.exception.UserErrorCode;
 import com.sparta.user.exception.UserException;
 import com.sparta.user.presentation.request.AddressRequest;
+import com.sparta.user.presentation.request.AddressRequest.Update;
 import com.sparta.user.user_dto.infrastructure.AddressDto;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -24,6 +26,7 @@ public class AddressService {
   private final UserRepository userRepository;
   private final AddressRepository addressRepository;
 
+  @Transactional
   public void createAddress(Long userId, AddressRequest.Create request) {
     User user = userRepository
         .findById(userId)
@@ -64,6 +67,17 @@ public class AddressService {
         .stream()
         .map(AddressResponse.Get::of)
         .collect(Collectors.toList());
+  }
+
+  @Transactional
+  public void updateAddress(Long userId, Long addressId, Update request) {
+    userRepository
+        .findById(userId)
+        .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+    Address address = addressRepository
+        .findById(addressId)
+        .orElseThrow(() -> new UserException(UserErrorCode.ADDRESS_NOT_FOUND));
+    address.update(request);
   }
 
 }

--- a/service/user/server/src/main/java/com/sparta/user/application/service/AddressService.java
+++ b/service/user/server/src/main/java/com/sparta/user/application/service/AddressService.java
@@ -2,6 +2,7 @@ package com.sparta.user.application.service;
 
 import static com.sparta.user.exception.UserErrorCode.USER_NOT_FOUND;
 
+import com.sparta.user.application.dto.AddressResponse;
 import com.sparta.user.domain.model.Address;
 import com.sparta.user.domain.model.User;
 import com.sparta.user.domain.repository.AddressRepository;
@@ -10,6 +11,8 @@ import com.sparta.user.exception.UserErrorCode;
 import com.sparta.user.exception.UserException;
 import com.sparta.user.presentation.request.AddressRequest;
 import com.sparta.user.user_dto.infrastructure.AddressDto;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -41,6 +44,17 @@ public class AddressService {
         address.getAddress(),
         address.getIsDefault()
     );
+  }
+
+  public List<AddressResponse.Get> getAddressByUserId(Long userId) {
+    User user = userRepository
+        .findById(userId)
+        .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+    return addressRepository
+        .findAllByUserId(user.getId())
+        .stream()
+        .map(AddressResponse.Get::of)
+        .collect(Collectors.toList());
   }
 
 }

--- a/service/user/server/src/main/java/com/sparta/user/application/service/AddressService.java
+++ b/service/user/server/src/main/java/com/sparta/user/application/service/AddressService.java
@@ -3,6 +3,7 @@ package com.sparta.user.application.service;
 import static com.sparta.user.exception.UserErrorCode.USER_NOT_FOUND;
 
 import com.sparta.user.application.dto.AddressResponse;
+import com.sparta.user.application.dto.AddressResponse.Get;
 import com.sparta.user.domain.model.Address;
 import com.sparta.user.domain.model.User;
 import com.sparta.user.domain.repository.AddressRepository;
@@ -52,6 +53,14 @@ public class AddressService {
         .orElseThrow(() -> new UserException(USER_NOT_FOUND));
     return addressRepository
         .findAllByUserId(user.getId())
+        .stream()
+        .map(AddressResponse.Get::of)
+        .collect(Collectors.toList());
+  }
+
+  public List<Get> getAddressList() {
+    return addressRepository
+        .findAll()
         .stream()
         .map(AddressResponse.Get::of)
         .collect(Collectors.toList());

--- a/service/user/server/src/main/java/com/sparta/user/domain/model/Address.java
+++ b/service/user/server/src/main/java/com/sparta/user/domain/model/Address.java
@@ -64,4 +64,13 @@ public class Address extends BaseEntity {
         .build();
   }
 
+  public void update(AddressRequest.Update request) {
+    this.alias = request.getAlias();
+    this.recipient = request.getRecipient();
+    this.phoneNumber = request.getPhoneNumber();
+    this.zipcode = request.getZipcode();
+    this.address = request.getAddress();
+    this.isDefault = request.getIsDefault();
+  }
+
 }

--- a/service/user/server/src/main/java/com/sparta/user/domain/model/vo/UserRole.java
+++ b/service/user/server/src/main/java/com/sparta/user/domain/model/vo/UserRole.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 public enum UserRole {
   ROLE_ADMIN("관리자"),
   ROLE_MANAGER("매니저"),
-  ROLE_CUSTOMER("고객");
+  ROLE_USER("사용자");
 
   private final String role;
 

--- a/service/user/server/src/main/java/com/sparta/user/domain/repository/AddressRepository.java
+++ b/service/user/server/src/main/java/com/sparta/user/domain/repository/AddressRepository.java
@@ -1,6 +1,7 @@
 package com.sparta.user.domain.repository;
 
 import com.sparta.user.domain.model.Address;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
@@ -10,5 +11,7 @@ public interface AddressRepository {
   Address save(Address address);
 
   Optional<Address> findById(Long addressId);
+
+  List<Address> findAllByUserId(Long userId);
 
 }

--- a/service/user/server/src/main/java/com/sparta/user/domain/repository/AddressRepository.java
+++ b/service/user/server/src/main/java/com/sparta/user/domain/repository/AddressRepository.java
@@ -14,4 +14,6 @@ public interface AddressRepository {
 
   List<Address> findAllByUserId(Long userId);
 
+  List<Address> findAll();
+
 }

--- a/service/user/server/src/main/java/com/sparta/user/domain/repository/AddressRepository.java
+++ b/service/user/server/src/main/java/com/sparta/user/domain/repository/AddressRepository.java
@@ -16,4 +16,6 @@ public interface AddressRepository {
 
   List<Address> findAll();
 
+  void delete(Address address);
+
 }

--- a/service/user/server/src/main/java/com/sparta/user/infrastructure/repository/AddressRepositoryImpl.java
+++ b/service/user/server/src/main/java/com/sparta/user/infrastructure/repository/AddressRepositoryImpl.java
@@ -33,4 +33,9 @@ public class AddressRepositoryImpl implements AddressRepository {
     return jpaAddressRepository.findAll();
   }
 
+  @Override
+  public void delete(Address address) {
+    jpaAddressRepository.delete(address);
+  }
+
 }

--- a/service/user/server/src/main/java/com/sparta/user/infrastructure/repository/AddressRepositoryImpl.java
+++ b/service/user/server/src/main/java/com/sparta/user/infrastructure/repository/AddressRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.sparta.user.infrastructure.repository;
 
 import com.sparta.user.domain.model.Address;
 import com.sparta.user.domain.repository.AddressRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -20,6 +21,11 @@ public class AddressRepositoryImpl implements AddressRepository {
   @Override
   public Optional<Address> findById(Long addressId) {
     return jpaAddressRepository.findById(addressId);
+  }
+
+  @Override
+  public List<Address> findAllByUserId(Long userId) {
+    return jpaAddressRepository.findAllByUserId(userId);
   }
 
 }

--- a/service/user/server/src/main/java/com/sparta/user/infrastructure/repository/AddressRepositoryImpl.java
+++ b/service/user/server/src/main/java/com/sparta/user/infrastructure/repository/AddressRepositoryImpl.java
@@ -28,4 +28,9 @@ public class AddressRepositoryImpl implements AddressRepository {
     return jpaAddressRepository.findAllByUserId(userId);
   }
 
+  @Override
+  public List<Address> findAll() {
+    return jpaAddressRepository.findAll();
+  }
+
 }

--- a/service/user/server/src/main/java/com/sparta/user/infrastructure/repository/JpaAddressRepository.java
+++ b/service/user/server/src/main/java/com/sparta/user/infrastructure/repository/JpaAddressRepository.java
@@ -1,8 +1,11 @@
 package com.sparta.user.infrastructure.repository;
 
 import com.sparta.user.domain.model.Address;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaAddressRepository extends JpaRepository<Address, Long> {
+
+  List<Address> findAllByUserId(Long userId);
 
 }

--- a/service/user/server/src/main/java/com/sparta/user/presentation/controller/AddressController.java
+++ b/service/user/server/src/main/java/com/sparta/user/presentation/controller/AddressController.java
@@ -2,10 +2,14 @@ package com.sparta.user.presentation.controller;
 
 import com.sparta.auth.auth_dto.jwt.JwtClaim;
 import com.sparta.common.domain.response.ApiResponse;
+import com.sparta.user.application.dto.AddressResponse;
 import com.sparta.user.application.service.AddressService;
 import com.sparta.user.presentation.request.AddressRequest;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +29,14 @@ public class AddressController {
   ) {
     addressService.createAddress(claim.getUserId(), request);
     return ApiResponse.ok();
+  }
+
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/me")
+  public ApiResponse<List<AddressResponse.Get>> getAddressByUserId(
+      @AuthenticationPrincipal JwtClaim claim
+  ) {
+    return ApiResponse.ok(addressService.getAddressByUserId(claim.getUserId()));
   }
 
 }

--- a/service/user/server/src/main/java/com/sparta/user/presentation/controller/AddressController.java
+++ b/service/user/server/src/main/java/com/sparta/user/presentation/controller/AddressController.java
@@ -10,6 +10,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -57,6 +58,16 @@ public class AddressController {
       @AuthenticationPrincipal JwtClaim claim
   ) {
     addressService.updateAddress(claim.getUserId(), addressId, request);
+    return ApiResponse.ok();
+  }
+
+  @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN') or hasRole('ROLE_MANAGER')")
+  @DeleteMapping("/{addressId}")
+  public ApiResponse<?> deleteAddress(
+      @PathVariable Long addressId,
+      @AuthenticationPrincipal JwtClaim claim
+  ) {
+    addressService.deleteAddress(claim.getUserId(), addressId);
     return ApiResponse.ok();
   }
 

--- a/service/user/server/src/main/java/com/sparta/user/presentation/controller/AddressController.java
+++ b/service/user/server/src/main/java/com/sparta/user/presentation/controller/AddressController.java
@@ -39,4 +39,11 @@ public class AddressController {
     return ApiResponse.ok(addressService.getAddressByUserId(claim.getUserId()));
   }
 
+  @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_MANAGER')")
+  @GetMapping
+  public ApiResponse<List<AddressResponse.Get>> getAddressList() {
+    return ApiResponse.ok(addressService.getAddressList());
+
+  }
+
 }

--- a/service/user/server/src/main/java/com/sparta/user/presentation/controller/AddressController.java
+++ b/service/user/server/src/main/java/com/sparta/user/presentation/controller/AddressController.java
@@ -5,11 +5,14 @@ import com.sparta.common.domain.response.ApiResponse;
 import com.sparta.user.application.dto.AddressResponse;
 import com.sparta.user.application.service.AddressService;
 import com.sparta.user.presentation.request.AddressRequest;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -44,6 +47,17 @@ public class AddressController {
   public ApiResponse<List<AddressResponse.Get>> getAddressList() {
     return ApiResponse.ok(addressService.getAddressList());
 
+  }
+
+  @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN') or hasRole('ROLE_MANAGER')")
+  @PatchMapping("/{addressId}")
+  public ApiResponse<?> updateAddress(
+      @PathVariable Long addressId,
+      @RequestBody @Valid AddressRequest.Update request,
+      @AuthenticationPrincipal JwtClaim claim
+  ) {
+    addressService.updateAddress(claim.getUserId(), addressId, request);
+    return ApiResponse.ok();
   }
 
 }

--- a/service/user/server/src/main/java/com/sparta/user/presentation/request/AddressRequest.java
+++ b/service/user/server/src/main/java/com/sparta/user/presentation/request/AddressRequest.java
@@ -26,5 +26,25 @@ public class AddressRequest {
     private Boolean isDefault;
 
   }
+  
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Update {
+
+    @NotNull
+    private String alias;
+    @NotNull
+    private String recipient;
+    @NotNull
+    private String phoneNumber;
+    @NotNull
+    private String zipcode;
+    @NotNull
+    private String address;
+    @NotNull
+    private Boolean isDefault;
+
+  }
 
 }

--- a/service/user/server/src/test/java/com/sparta/user/http/AddressApiTest.http
+++ b/service/user/server/src/test/java/com/sparta/user/http/AddressApiTest.http
@@ -1,11 +1,12 @@
 @Port=19091
 @InternalPort=19092
-@Token=Bearer eyJhbGciOiJIUzI1NiJ9.eyJVU0VSX0lEIjoxMCwiVVNFUl9ST0xFIjoiUk9MRV9VU0VSIiwiVVNFUl9OQU1FIjoibmV3VXNlcjIiLCJpYXQiOjE3Mjg2NTUxOTgsImV4cCI6MTczMjI1NTE5OH0.o6VKKVIrBV1SNtlPCbVOWygPhcNGvmLKJsrXMvp8rgI
+@TokenUser=Bearer eyJhbGciOiJIUzI1NiJ9.eyJVU0VSX0lEIjoxMCwiVVNFUl9ST0xFIjoiUk9MRV9VU0VSIiwiVVNFUl9OQU1FIjoibmV3VXNlcjIiLCJpYXQiOjE3Mjg2NTUxOTgsImV4cCI6MTczMjI1NTE5OH0.o6VKKVIrBV1SNtlPCbVOWygPhcNGvmLKJsrXMvp8rgI
+@TokenAdmin=Bearer eyJhbGciOiJIUzI1NiJ9.eyJVU0VSX0lEIjoxMSwiVVNFUl9ST0xFIjoiUk9MRV9BRE1JTiIsIlVTRVJfTkFNRSI6Im5ld1VzZXIiLCJpYXQiOjE3Mjg2NTYxMjUsImV4cCI6MTczMjI1NjEyNX0.z_M-s8XwM2SKA7ojdNR9ZoMRd7isn8VLlKmL0i5iI4s
 
 ### (외부)배송지 등록
 POST http://localhost:{{Port}}/api/address
 Content-Type: application/json
-Authorization: {{Token}}
+Authorization: {{TokenUser}}
 
 {
   "alias": "집2",
@@ -18,8 +19,11 @@ Authorization: {{Token}}
 
 ### 내 배송지 조회
 GET http://localhost:{{Port}}/api/address/me
-Authorization: {{Token}}
+Authorization: {{TokenUser}}
 
+### 배송지 전체 조회(관리자)
+GET http://localhost:{{Port}}/api/address
+Authorization: {{TokenAdmin}}
 
 ### (내부)배송지 단일 조회
 @addressId = 1

--- a/service/user/server/src/test/java/com/sparta/user/http/AddressApiTest.http
+++ b/service/user/server/src/test/java/com/sparta/user/http/AddressApiTest.http
@@ -25,6 +25,20 @@ Authorization: {{TokenUser}}
 GET http://localhost:{{Port}}/api/address
 Authorization: {{TokenAdmin}}
 
+### 배송지 수정
+@addressId = 2
+PATCH http://localhost:{{Port}}/api/address/{{addressId}}
+Content-Type: application/json
+Authorization: {{TokenUser}}
+
+{
+  "alias": "회사",
+  "recipient": "김철수",
+  "phoneNumber": "010-9876-5432",
+  "zipcode": "54321",
+  "address": "서울시 서초구 서초대로 456",
+  "isDefault": true
+}
+
 ### (내부)배송지 단일 조회
-@addressId = 1
 GET http://localhost:{{InternalPort}}/internal/address/{{addressId}}

--- a/service/user/server/src/test/java/com/sparta/user/http/AddressApiTest.http
+++ b/service/user/server/src/test/java/com/sparta/user/http/AddressApiTest.http
@@ -40,5 +40,9 @@ Authorization: {{TokenUser}}
   "isDefault": true
 }
 
+### 배송지 삭제
+DELETE http://localhost:{{Port}}/api/address/{{addressId}}
+Authorization: {{TokenUser}}
+
 ### (내부)배송지 단일 조회
 GET http://localhost:{{InternalPort}}/internal/address/{{addressId}}

--- a/service/user/server/src/test/java/com/sparta/user/http/AddressApiTest.http
+++ b/service/user/server/src/test/java/com/sparta/user/http/AddressApiTest.http
@@ -1,6 +1,6 @@
 @Port=19091
 @InternalPort=19092
-@Token=Bearer eyJhbGciOiJIUzI1NiJ9.eyJVU0VSX0lEIjo3LCJVU0VSX1JPTEUiOiJST0xFX0FETUlOIiwiVVNFUl9OQU1FIjoibmV3VXNlciIsImlhdCI6MTcyODQ2MjUxOSwiZXhwIjoxNzMyMDYyNTE5fQ.gbr5aA9ZocMY5g7PoLepnVuAnXqQ6djVzfDKxcT3yNM
+@Token=Bearer eyJhbGciOiJIUzI1NiJ9.eyJVU0VSX0lEIjoxMCwiVVNFUl9ST0xFIjoiUk9MRV9VU0VSIiwiVVNFUl9OQU1FIjoibmV3VXNlcjIiLCJpYXQiOjE3Mjg2NTUxOTgsImV4cCI6MTczMjI1NTE5OH0.o6VKKVIrBV1SNtlPCbVOWygPhcNGvmLKJsrXMvp8rgI
 
 ### (외부)배송지 등록
 POST http://localhost:{{Port}}/api/address
@@ -8,13 +8,18 @@ Content-Type: application/json
 Authorization: {{Token}}
 
 {
-  "alias": "집",
-  "recipient": "홍길동",
-  "phoneNumber": "010-1234-5678",
-  "zipcode": "12345",
-  "address": "서울시 강남구 테헤란로 123",
+  "alias": "집2",
+  "recipient": "홍길동2",
+  "phoneNumber": "010-1234-4321",
+  "zipcode": "12347",
+  "address": "서울시 강남구 테헤란로 456",
   "isDefault": false
 }
+
+### 내 배송지 조회
+GET http://localhost:{{Port}}/api/address/me
+Authorization: {{Token}}
+
 
 ### (내부)배송지 단일 조회
 @addressId = 1

--- a/service/user/server/src/test/java/com/sparta/user/service/AddressServiceTest.java
+++ b/service/user/server/src/test/java/com/sparta/user/service/AddressServiceTest.java
@@ -24,6 +24,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -42,7 +43,8 @@ public class AddressServiceTest {
   private AddressService addressService;
 
   @Test
-  void 배송지_생성() {
+  @DisplayName("배송지 생성")
+  void use_1() {
     // given
     UserRequest.Create userRequest = new UserRequest.Create(
         "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
@@ -67,7 +69,8 @@ public class AddressServiceTest {
   }
 
   @Test
-  void 배송지_생성_사용자없음_예외발생() {
+  @DisplayName("배송지 생성 사용자 없을 시 예외 발생")
+  void use_2() {
     // given
     Long userId = 1L;
     AddressRequest.Create addressRequest = new AddressRequest.Create(
@@ -92,7 +95,8 @@ public class AddressServiceTest {
   }
 
   @Test
-  void 배송지_단일조회_성공() {
+  @DisplayName("배송지 단일 조회 성공")
+  void use_3() {
     // given
     UserRequest.Create userRequest = new UserRequest.Create(
         "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
@@ -125,7 +129,8 @@ public class AddressServiceTest {
   }
 
   @Test
-  void 배송지_단일조회_실패() {
+  @DisplayName("배송지 단일 조회 실패")
+  void use_4() {
     // given
     Long addressId = 1L;
 
@@ -140,7 +145,8 @@ public class AddressServiceTest {
   }
 
   @Test
-  void 현재_사용자_배송지_조회() {
+  @DisplayName("현재 사용자 배송지 조회")
+  void use_5() {
     // given
     Long userId = 1L;
     UserRequest.Create userRequest = new UserRequest.Create(
@@ -176,6 +182,43 @@ public class AddressServiceTest {
     assertEquals(2, result.size());
     verify(userRepository, times(1)).findById(userId);
     verify(addressRepository, times(1)).findAllByUserId(user.getId());
+  }
+
+  @Test
+  @DisplayName("전체 배송지 조회")
+  void use_6() {
+    // given
+    UserRequest.Create userRequest = new UserRequest.Create(
+        "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
+    );
+    User user = User.create(userRequest, "encodedPassword");
+
+    List<Address> addressList = Arrays.asList(
+        Address.create(user, new AddressRequest.Create(
+            "집",
+            "홍길동",
+            "010-1234-5678",
+            "12345",
+            "서울시 강남구 테헤란로 123",
+            true
+        )),
+        Address.create(user, new AddressRequest.Create(
+            "집2",
+            "홍길동2",
+            "010-1234-4321",
+            "12347",
+            "서울시 강남구 테헤란로 456",
+            false
+        ))
+    );
+
+    // when
+    when(addressRepository.findAll()).thenReturn(addressList);
+
+    // then
+    List<AddressResponse.Get> result = addressService.getAddressList();
+    assertEquals(2, result.size());
+    verify(addressRepository, times(1)).findAll();
   }
 
 }

--- a/service/user/server/src/test/java/com/sparta/user/service/AddressServiceTest.java
+++ b/service/user/server/src/test/java/com/sparta/user/service/AddressServiceTest.java
@@ -2,6 +2,7 @@ package com.sparta.user.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -219,6 +220,52 @@ public class AddressServiceTest {
     List<AddressResponse.Get> result = addressService.getAddressList();
     assertEquals(2, result.size());
     verify(addressRepository, times(1)).findAll();
+  }
+
+  @Test
+  @DisplayName("배송지 수정")
+  void use_7() {
+    // given
+    Long userId = 1L;
+    UserRequest.Create userRequest = new UserRequest.Create(
+        "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
+    );
+    User user = User.create(userRequest, "encodedPassword");
+    Long addressId = 1L;
+    Address address = Address.create(user, new AddressRequest.Create(
+        "집",
+        "홍길동",
+        "010-1234-5678",
+        "12345",
+        "서울시 강남구 테헤란로 123",
+        false
+    ));
+
+    AddressRequest.Update addressUpdateRequest = new AddressRequest.Update(
+        "회사",
+        "김철수",
+        "010-9876-5432",
+        "54321",
+        "서울시 서초구 서초대로 456",
+        true
+    );
+
+    // when
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(addressRepository.findById(userId)).thenReturn(Optional.of(address));
+
+    // then
+    addressService.updateAddress(userId, addressId, addressUpdateRequest);
+
+    assertEquals("회사", address.getAlias());
+    assertEquals("김철수", address.getRecipient());
+    assertEquals("010-9876-5432", address.getPhoneNumber());
+    assertEquals("54321", address.getZipcode());
+    assertEquals("서울시 서초구 서초대로 456", address.getAddress());
+    assertTrue(address.getIsDefault());
+
+    verify(userRepository, times(1)).findById(userId);
+    verify(addressRepository, times(1)).findById(addressId);
   }
 
 }

--- a/service/user/server/src/test/java/com/sparta/user/service/AddressServiceTest.java
+++ b/service/user/server/src/test/java/com/sparta/user/service/AddressServiceTest.java
@@ -25,7 +25,6 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -44,8 +43,7 @@ public class AddressServiceTest {
   private AddressService addressService;
 
   @Test
-  @DisplayName("배송지 생성")
-  void use_1() {
+  void test_배송지_생성() {
     // given
     UserRequest.Create userRequest = new UserRequest.Create(
         "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
@@ -70,8 +68,7 @@ public class AddressServiceTest {
   }
 
   @Test
-  @DisplayName("배송지 생성 사용자 없을 시 예외 발생")
-  void use_2() {
+  void test_배송지_생성_사용자_없을_시_예외_발생() {
     // given
     Long userId = 1L;
     AddressRequest.Create addressRequest = new AddressRequest.Create(
@@ -96,8 +93,7 @@ public class AddressServiceTest {
   }
 
   @Test
-  @DisplayName("배송지 단일 조회 성공")
-  void use_3() {
+  void test_배송지_단일_조회_성공() {
     // given
     UserRequest.Create userRequest = new UserRequest.Create(
         "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
@@ -130,8 +126,7 @@ public class AddressServiceTest {
   }
 
   @Test
-  @DisplayName("배송지 단일 조회 실패")
-  void use_4() {
+  void test_배송지_단일_조회_실패() {
     // given
     Long addressId = 1L;
 
@@ -146,8 +141,7 @@ public class AddressServiceTest {
   }
 
   @Test
-  @DisplayName("현재 사용자 배송지 조회")
-  void use_5() {
+  void test_현재_사용자_배송지_조회() {
     // given
     Long userId = 1L;
     UserRequest.Create userRequest = new UserRequest.Create(
@@ -186,8 +180,7 @@ public class AddressServiceTest {
   }
 
   @Test
-  @DisplayName("전체 배송지 조회")
-  void use_6() {
+  void test_전체_배송지_조회() {
     // given
     UserRequest.Create userRequest = new UserRequest.Create(
         "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
@@ -223,15 +216,14 @@ public class AddressServiceTest {
   }
 
   @Test
-  @DisplayName("배송지 수정")
-  void use_7() {
+  void test_배송지_수정() {
     // given
     Long userId = 1L;
+    Long addressId = 1L;
     UserRequest.Create userRequest = new UserRequest.Create(
         "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
     );
     User user = User.create(userRequest, "encodedPassword");
-    Long addressId = 1L;
     Address address = Address.create(user, new AddressRequest.Create(
         "집",
         "홍길동",
@@ -240,7 +232,6 @@ public class AddressServiceTest {
         "서울시 강남구 테헤란로 123",
         false
     ));
-
     AddressRequest.Update addressUpdateRequest = new AddressRequest.Update(
         "회사",
         "김철수",
@@ -266,6 +257,38 @@ public class AddressServiceTest {
 
     verify(userRepository, times(1)).findById(userId);
     verify(addressRepository, times(1)).findById(addressId);
+  }
+
+  @Test
+  void test_배송지_삭제() {
+    // given
+    Long userId = 1L;
+    Long addressId = 1L;
+
+    UserRequest.Create userRequest = new UserRequest.Create(
+        "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
+    );
+    User user = User.create(userRequest, "encodedPassword");
+    Address address = Address.create(user, new AddressRequest.Create(
+        "집",
+        "홍길동",
+        "010-1234-5678",
+        "12345",
+        "서울시 강남구 테헤란로 123",
+        false
+    ));
+
+    // when
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(addressRepository.findById(addressId)).thenReturn(Optional.of(address));
+
+    // delete 주소 실행
+    addressService.deleteAddress(userId, addressId);
+
+    // then
+    verify(userRepository, times(1)).findById(userId);
+    verify(addressRepository, times(1)).findById(addressId);
+    verify(addressRepository, times(1)).delete(address);
   }
 
 }

--- a/service/user/server/src/test/java/com/sparta/user/service/PointHistoryServiceTests.java
+++ b/service/user/server/src/test/java/com/sparta/user/service/PointHistoryServiceTests.java
@@ -40,7 +40,7 @@ public class PointHistoryServiceTests {
   void test_포인트_내역_추가_성공() {
     // Given
     UserRequest.Create userRequest = new UserRequest.Create(
-        "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_CUSTOMER
+        "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
     );
     User user = User.create(userRequest, "encodedPassword");
     PointHistoryDto request = new PointHistoryDto(
@@ -88,7 +88,7 @@ public class PointHistoryServiceTests {
   void test_포인트_내역_추가_시_유저의_포인트_부족() {
     // Given
     UserRequest.Create userRequest = new UserRequest.Create(
-        "username", "password", "nickname", new BigDecimal("100"), UserRole.ROLE_CUSTOMER
+        "username", "password", "nickname", new BigDecimal("100"), UserRole.ROLE_USER
     );
     User user = User.create(userRequest, "encodedPassword");
     PointHistoryDto request = new PointHistoryDto(


### PR DESCRIPTION
## 🎯 What is this PR

- 배송지 관련 기능 구현

## 📄 Changes Made

### 구현 완료
   - 내 배송지 조회
   - 배송지 전체 조회
   - 배송지 수정
   - 배송지 삭제
 
### 수정
- 유저 권한 이름 수정 (ROLE_CUSTOMER > ROLE_USER)
   - **현재 유저 테이블을 만들었다면 수정 필요**
![1](https://github.com/user-attachments/assets/7a5e2fb1-ffe7-4010-a3b8-4f1ebfda705a)
![2](https://github.com/user-attachments/assets/324aac59-118a-451f-b21f-8c98a0ff6c3d)
![3](https://github.com/user-attachments/assets/126f2c95-9067-4a95-be4c-029f5a6dd8ce)
81b60)

- 이미지와 같이 경로를 따라서 user 테이블의 role 컬럼을 ROLE_CUSTOMER > ROLE_USER로 수정

## 🙋🏻‍ Review Point

- 기존에 만들었던 유저 테이블의 경우 수정을 안하면 에러가 발생합니다. 꼭 수정하고 사용해주세요.

## Require

- 배송지 삭제 시 유저는 자기 자신만 매니저, 관리자는 모두 삭제 가능하도록 수정 필요

## ✅ Test

- [x] 단위 테스트
![image](https://github.com/user-attachments/assets/0631bf73-cb06-4c9c-9c9e-e81d81646a06)

## 🔗 Reference

Issue #75 