### PR TITLE
상품 등록시 카테고리 검증 및 재고감소 내부 API 구현

### DIFF
--- a/service/product/server/src/main/java/com/sparta/product/application/category/CategoryCache.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/category/CategoryCache.java
@@ -1,4 +1,4 @@
-package com.sparta.product.application;
+package com.sparta.product.application.category;
 
 import com.sparta.product.presentation.response.CategoryResponse;
 import java.util.List;

--- a/service/product/server/src/main/java/com/sparta/product/application/category/CategoryService.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/category/CategoryService.java
@@ -1,4 +1,4 @@
-package com.sparta.product.application;
+package com.sparta.product.application.category;
 
 import com.sparta.product.domain.model.Category;
 import com.sparta.product.domain.repository.jpa.CategoryRepository;
@@ -60,6 +60,10 @@ public class CategoryService {
         .filter(category -> category.getParent() == null)
         .map(CategoryResponse::fromEntity)
         .collect(Collectors.toList());
+  }
+
+  public boolean existsCategory(Long categoryId) {
+    return categoryRepository.existsByCategoryId(categoryId);
   }
 
   private void syncParentCategory(Category target, Category newParent) {

--- a/service/product/server/src/main/java/com/sparta/product/application/product/ElasticsearchService.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/product/ElasticsearchService.java
@@ -1,4 +1,4 @@
-package com.sparta.product.application;
+package com.sparta.product.application.product;
 
 import com.sparta.product.domain.model.SortOption;
 import com.sparta.product.domain.repository.ElasticSearchRepository;
@@ -52,10 +52,20 @@ public class ElasticsearchService {
       Long maxPrice,
       String productSize,
       String mainColor,
-      String sortOption) throws IOException {
+      String sortOption)
+      throws IOException {
     SortOption sort = SortOption.valueOf(sortOption.toUpperCase());
     Pageable pageable = PageRequest.of(page, size, Sort.by(sort.getField()));
     return customRepository.searchProductList(
-        categoryId, brandName, minPrice, maxPrice, productSize, mainColor, page, size, pageable, sort);
+        categoryId,
+        brandName,
+        minPrice,
+        maxPrice,
+        productSize,
+        mainColor,
+        page,
+        size,
+        pageable,
+        sort);
   }
 }

--- a/service/product/server/src/main/java/com/sparta/product/application/product/ProductFacadeService.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/product/ProductFacadeService.java
@@ -1,5 +1,8 @@
-package com.sparta.product.application;
+package com.sparta.product.application.product;
 
+import com.sparta.product.application.category.CategoryService;
+import com.sparta.product.presentation.exception.ProductErrorCode;
+import com.sparta.product.presentation.exception.ProductServerException;
 import com.sparta.product.presentation.request.ProductCreateRequest;
 import com.sparta.product.presentation.request.ProductUpdateRequest;
 import com.sparta.product.presentation.response.ProductResponse;
@@ -13,15 +16,22 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class ProductFacadeService {
   private final ProductService productService;
+  private final CategoryService categoryService;
   private final ElasticsearchService elasticSearchService;
 
   public String createProduct(ProductCreateRequest request) {
+    if (!categoryService.existsCategory(request.categoryId())) {
+      throw new ProductServerException(ProductErrorCode.NOT_FOUND_CATEGORY);
+    }
     ProductResponse product = productService.createProduct(request);
     elasticSearchService.saveProduct(product);
     return product.getProductId();
   }
 
   public ProductResponse updateProduct(ProductUpdateRequest request) {
+    if (!categoryService.existsCategory(request.categoryId())) {
+      throw new ProductServerException(ProductErrorCode.NOT_FOUND_CATEGORY);
+    }
     ProductResponse product = productService.updateProduct(request);
     elasticSearchService.updateProduct(product);
     return product;

--- a/service/product/server/src/main/java/com/sparta/product/application/product/ProductMapper.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/product/ProductMapper.java
@@ -1,4 +1,4 @@
-package com.sparta.product.application;
+package com.sparta.product.application.product;
 
 import com.sparta.product.domain.model.Product;
 import com.sparta.product.presentation.request.ProductCreateRequest;
@@ -54,5 +54,4 @@ public class ProductMapper {
         request.tags(),
         request.isPublic());
   }
-
 }

--- a/service/product/server/src/main/java/com/sparta/product/application/product/ProductService.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/product/ProductService.java
@@ -9,6 +9,7 @@ import com.sparta.product.presentation.request.ProductUpdateRequest;
 import com.sparta.product.presentation.response.ProductResponse;
 import com.sparta.product_dto.ProductDto;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -50,6 +51,18 @@ public class ProductService {
     product.isDelete();
     productRepository.save(product);
     return ProductResponse.fromEntity(product);
+  }
+
+  public void reduceStock(Map<String, Integer> productQuantities) {
+    productQuantities.entrySet().stream()
+        .forEach(
+            entry -> {
+              String productId = entry.getKey();
+              int reduceCount = entry.getValue();
+              Product product = getSavedProduct(UUID.fromString(productId));
+              product.updateStock(reduceCount);
+              productRepository.save(product);
+            });
   }
 
   public ProductResponse getProduct(UUID productId) {

--- a/service/product/server/src/main/java/com/sparta/product/application/product/ProductService.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/product/ProductService.java
@@ -1,4 +1,4 @@
-package com.sparta.product.application;
+package com.sparta.product.application.product;
 
 import com.sparta.product.domain.model.Product;
 import com.sparta.product.domain.repository.cassandra.ProductRepository;

--- a/service/product/server/src/main/java/com/sparta/product/application/product/ProductService.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/product/ProductService.java
@@ -1,6 +1,7 @@
 package com.sparta.product.application.product;
 
 import com.sparta.product.domain.model.Product;
+import com.sparta.product.domain.model.SortOption;
 import com.sparta.product.domain.repository.cassandra.ProductRepository;
 import com.sparta.product.presentation.exception.ProductErrorCode;
 import com.sparta.product.presentation.exception.ProductServerException;
@@ -8,16 +9,25 @@ import com.sparta.product.presentation.request.ProductCreateRequest;
 import com.sparta.product.presentation.request.ProductUpdateRequest;
 import com.sparta.product.presentation.response.ProductResponse;
 import com.sparta.product_dto.ProductDto;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j(topic = "ProductService")
 public class ProductService {
   private final ProductRepository productRepository;
 
@@ -67,6 +77,36 @@ public class ProductService {
 
   public ProductResponse getProduct(UUID productId) {
     return ProductResponse.fromEntity(getSavedProduct(productId));
+  }
+
+  public Page<ProductResponse> getProductList(
+      int page,
+      int size,
+      Long categoryId,
+      String brandName,
+      Long minPrice,
+      Long maxPrice,
+      String productSize,
+      String mainColor,
+      String sortOption) {
+    SortOption sort = SortOption.valueOf(sortOption.toUpperCase());
+    Sort.Direction direction =
+        sort.getOrder().name().contains("Asc") ? Direction.ASC : Direction.DESC;
+    Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sort.getField()));
+    List<ProductResponse> result =
+        productRepository
+            .findAllByFilters(
+                categoryId,
+                brandName,
+                BigDecimal.valueOf(minPrice),
+                BigDecimal.valueOf(maxPrice),
+                productSize,
+                mainColor,
+                pageable)
+            .stream()
+            .map(ProductResponse::fromEntity)
+            .toList();
+    return new PageImpl<>(result, pageable, result.size());
   }
 
   public List<ProductDto> getProductList(List<String> productIds) {

--- a/service/product/server/src/main/java/com/sparta/product/domain/model/Product.java
+++ b/service/product/server/src/main/java/com/sparta/product/domain/model/Product.java
@@ -142,4 +142,8 @@ public class Product extends BaseEntity implements Persistable {
       this.discountedPrice = this.originalPrice;
     }
   }
+
+  public void updateStock(int reduceCount) {
+    this.stock -= reduceCount;
+  }
 }

--- a/service/product/server/src/main/java/com/sparta/product/domain/repository/cassandra/ProductRepository.java
+++ b/service/product/server/src/main/java/com/sparta/product/domain/repository/cassandra/ProductRepository.java
@@ -1,12 +1,33 @@
 package com.sparta.product.domain.repository.cassandra;
 
 import com.sparta.product.domain.model.Product;
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.cassandra.repository.CassandraRepository;
+import org.springframework.data.cassandra.repository.Query;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepository extends CassandraRepository<Product, UUID> {
   Optional<Product> findByProductIdAndIsDeletedFalse(UUID productId);
+
+  @Query(
+      "SELECT * FROM \"P_PRODUCT\" WHERE "
+          + "(categoryId = ?0) AND "
+          + "(brandName = ?1) AND "
+          + "(originalPrice >= ?2) AND "
+          + "(originalPrice <= ?3) AND "
+          + "(size = ?4) AND "
+          + "(mainColor = ?5) ALLOW FILTERING")
+  List<Product> findAllByFilters(
+      Long categoryId,
+      String brandName,
+      BigDecimal minPrice,
+      BigDecimal maxPrice,
+      String productSize,
+      String mainColor,
+      Pageable pageable);
 }

--- a/service/product/server/src/main/java/com/sparta/product/domain/repository/jpa/CategoryRepository.java
+++ b/service/product/server/src/main/java/com/sparta/product/domain/repository/jpa/CategoryRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.Query;
 public interface CategoryRepository extends JpaRepository<Category, Long> {
   Optional<Category> findByCategoryId(Long categoryId);
 
+  boolean existsByCategoryId(Long categoryId);
+
   @Query("SELECT c FROM Category c LEFT JOIN FETCH c.subCategories")
   List<Category> findAllWithSubCategories();
 }

--- a/service/product/server/src/main/java/com/sparta/product/presentation/controller/CategoryController.java
+++ b/service/product/server/src/main/java/com/sparta/product/presentation/controller/CategoryController.java
@@ -1,7 +1,7 @@
 package com.sparta.product.presentation.controller;
 
 import com.sparta.common.domain.response.ApiResponse;
-import com.sparta.product.application.CategoryService;
+import com.sparta.product.application.category.CategoryService;
 import com.sparta.product.presentation.request.CategoryCreateRequest;
 import com.sparta.product.presentation.request.CategoryUpdateRequest;
 import com.sparta.product.presentation.response.CategoryResponse;

--- a/service/product/server/src/main/java/com/sparta/product/presentation/controller/ProductController.java
+++ b/service/product/server/src/main/java/com/sparta/product/presentation/controller/ProductController.java
@@ -7,9 +7,13 @@ import com.sparta.product.presentation.request.ProductCreateRequest;
 import com.sparta.product.presentation.request.ProductUpdateRequest;
 import com.sparta.product.presentation.response.ProductResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import java.io.IOException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -55,5 +59,30 @@ public class ProductController {
   public ApiResponse<ProductResponse> getProduct(
       @PathVariable("productId") @NotNull UUID productId) {
     return ApiResponse.ok(productService.getProduct(productId));
+  }
+
+  @GetMapping
+  public ApiResponse<Page<ProductResponse>> getProductList(
+      @RequestParam(defaultValue = "0") @Min(0) int page,
+      @RequestParam(defaultValue = "30") @Min(1) @Max(100) int size,
+      @RequestParam("categoryId") Long categoryId,
+      @RequestParam(value = "brandName", required = false) String brandName,
+      @RequestParam(name = "minPrice", defaultValue = "1000") @Min(1000) Long minPrice,
+      @RequestParam(value = "maxPrice", required = false) Long maxPrice,
+      @RequestParam(value = "productSize", required = false) String productSize,
+      @RequestParam(value = "mainColor", required = false) String mainColor,
+      @RequestParam(value = "sort", defaultValue = "newest") String sortOption)
+      throws IOException {
+    return ApiResponse.ok(
+        productService.getProductList(
+            page,
+            size,
+            categoryId,
+            brandName,
+            minPrice,
+            maxPrice,
+            productSize,
+            mainColor,
+            sortOption));
   }
 }

--- a/service/product/server/src/main/java/com/sparta/product/presentation/controller/ProductController.java
+++ b/service/product/server/src/main/java/com/sparta/product/presentation/controller/ProductController.java
@@ -1,8 +1,8 @@
 package com.sparta.product.presentation.controller;
 
 import com.sparta.common.domain.response.ApiResponse;
-import com.sparta.product.application.ProductFacadeService;
-import com.sparta.product.application.ProductService;
+import com.sparta.product.application.product.ProductFacadeService;
+import com.sparta.product.application.product.ProductService;
 import com.sparta.product.presentation.request.ProductCreateRequest;
 import com.sparta.product.presentation.request.ProductUpdateRequest;
 import com.sparta.product.presentation.response.ProductResponse;

--- a/service/product/server/src/main/java/com/sparta/product/presentation/controller/ProductInternalController.java
+++ b/service/product/server/src/main/java/com/sparta/product/presentation/controller/ProductInternalController.java
@@ -3,8 +3,10 @@ package com.sparta.product.presentation.controller;
 import com.sparta.product.application.product.ProductService;
 import com.sparta.product_dto.ProductDto;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,5 +22,10 @@ public class ProductInternalController {
   public List<ProductDto> getProductList(
       @RequestParam(name = "productIds") List<String> productIds) {
     return productService.getProductList(productIds);
+  }
+
+  @PatchMapping("/reduceStock")
+  public void updateStock(Map<String, Integer> productQuantities) {
+    productService.reduceStock(productQuantities);
   }
 }

--- a/service/product/server/src/main/java/com/sparta/product/presentation/controller/ProductInternalController.java
+++ b/service/product/server/src/main/java/com/sparta/product/presentation/controller/ProductInternalController.java
@@ -1,6 +1,6 @@
 package com.sparta.product.presentation.controller;
 
-import com.sparta.product.application.ProductService;
+import com.sparta.product.application.product.ProductService;
 import com.sparta.product_dto.ProductDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -21,5 +21,4 @@ public class ProductInternalController {
       @RequestParam(name = "productIds") List<String> productIds) {
     return productService.getProductList(productIds);
   }
-
 }

--- a/service/product/server/src/main/java/com/sparta/product/presentation/controller/ProductSearchController.java
+++ b/service/product/server/src/main/java/com/sparta/product/presentation/controller/ProductSearchController.java
@@ -2,7 +2,7 @@ package com.sparta.product.presentation.controller;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.sparta.common.domain.response.ApiResponse;
-import com.sparta.product.application.ElasticsearchService;
+import com.sparta.product.application.product.ElasticsearchService;
 import com.sparta.product.infrastructure.elasticsearch.dto.ProductSearchDto;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;


### PR DESCRIPTION
## 🎯 What is this PR
- 상품 도메인에 추가로직 구현 

## 📄 Changes Made
- 상품등록/수정시 request로 받은 categoryId를 검증하는 로직 추가 
- 주문서버에서 사용할 재고감소 내부 API 구현
- 중간발표에서 성능비교시 사용했던 카산드라에서 조회하는 상품목록 API도 추가 

## 🙋🏻‍ Review Point
- Product는 cassandra jpa를 쓰기떄문에 변경감지 기능이 활성화되지 않아 stock을 update하고 변경된 값을 다시 repository에 넣어줘야한다는점 참고바랍니다 
- 동시성처리, 예외는 주문개발이신 @eggnee님이 담당하신다고 해서 API 인터페이스만 구성해놨습니다 

## ✅ Test
> 상품등록시 없는 카테고리에 404 예외발생 
<img width="872" alt="스크린샷 2024-10-12 오전 12 30 54" src="https://github.com/user-attachments/assets/07f7b268-6fcb-4ed6-8001-5d3cf78a2974">


> 상품목록조회 API by Cassandra
<img width="784" alt="image" src="https://github.com/user-attachments/assets/aff49984-1825-4c77-9260-d133c3f1beca">

## 🔗 Reference
Issue #88