### PR TITLE
사전예약 등록, 수정, 삭제, 조회 API 구현 

### DIFF
--- a/service/gateway/server/src/main/resources/application-local.yml
+++ b/service/gateway/server/src/main/resources/application-local.yml
@@ -22,7 +22,7 @@ spring:
         - id: product
           uri: lb://product
           predicates:
-            - Path=/api/products/**, /api/preproducts/**, /api/categories/**,
+            - Path=/api/products/**, /api/preorders/**, /api/categories/**,
 
         - id: promotion
           uri: lb://promotion

--- a/service/product/server/src/main/java/com/sparta/product/application/preorder/PreOrderMapper.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/preorder/PreOrderMapper.java
@@ -1,0 +1,17 @@
+package com.sparta.product.application.preorder;
+
+import com.sparta.product.domain.model.PreOrder;
+import com.sparta.product.presentation.request.PreOrderCreateRequest;
+
+public class PreOrderMapper {
+  public static PreOrder toEntity(PreOrderCreateRequest request) {
+    return PreOrder.builder()
+        .productId(request.productId())
+        .preOrderTitle(request.preOrderTitle())
+        .startDateTime(request.startDateTime())
+        .endDateTime(request.endDateTime())
+        .releaseDateTime(request.releaseDateTime())
+        .availableQuantity(request.availableQuantity())
+        .build();
+  }
+}

--- a/service/product/server/src/main/java/com/sparta/product/application/preorder/PreOrderService.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/preorder/PreOrderService.java
@@ -1,0 +1,94 @@
+package com.sparta.product.application.preorder;
+
+import com.sparta.product.domain.model.PreOrder;
+import com.sparta.product.domain.model.PreOrderState;
+import com.sparta.product.domain.model.Product;
+import com.sparta.product.domain.repository.cassandra.ProductRepository;
+import com.sparta.product.domain.repository.jpa.PreOrderRepository;
+import com.sparta.product.presentation.exception.ProductErrorCode;
+import com.sparta.product.presentation.exception.ProductServerException;
+import com.sparta.product.presentation.request.PreOrderCreateRequest;
+import com.sparta.product.presentation.request.PreOrderUpdateRequest;
+import com.sparta.product.presentation.response.PreOrderResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class PreOrderService {
+  private final PreOrderRepository preOrderRepository;
+  private final ProductRepository productRepository;
+
+  public Long createPreOrder(PreOrderCreateRequest request) {
+    Product product = getProductByProductId(request.productId());
+    validateStock(product.getStock(), request.availableQuantity());
+    PreOrder preOrder = PreOrderMapper.toEntity(request);
+    PreOrder savedPreOrder = preOrderRepository.save(preOrder);
+    return savedPreOrder.getPreOrderId();
+  }
+
+  public PreOrderResponse updatePreOrder(PreOrderUpdateRequest request) {
+    PreOrder preOrder = findPreOrderByPreOrderId(request.preOrderId());
+    if (preOrder.getProductId() != request.productId()) {
+      Product product = getProductByProductId(request.productId());
+      validateStock(product.getStock(), request.availableQuantity());
+    }
+    preOrder.update(
+        request.productId(),
+        request.preOrderTitle(),
+        request.startDateTime(),
+        request.endDateTime(),
+        request.releaseDateTime(),
+        request.availableQuantity());
+    return PreOrderResponse.of(preOrder);
+  }
+
+  @Transactional(readOnly = true)
+  public PreOrderResponse getPreOrder(Long preOrderId) {
+    return PreOrderResponse.of(findPreOrderByPreOrderId(preOrderId));
+  }
+
+  @Transactional(readOnly = true)
+  public Page<PreOrderResponse> getPreOrderList(int page, int size) {
+    Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+    return preOrderRepository.findAllByIsPublicTrue(pageable).map(PreOrderResponse::of);
+  }
+
+  public PreOrderResponse updateState(Long preOrderId, PreOrderState state) {
+    PreOrder preOrder = findPreOrderByPreOrderId(preOrderId);
+    if (state == PreOrderState.OPEN_FOR_ORDER) preOrder.open();
+    else if (state == PreOrderState.CANCELLED) preOrder.cancel(); // TODO :: 해당 주문건들 sate 전파필요
+    return PreOrderResponse.of(preOrder);
+  }
+
+  public void deletePreOrder(Long preOrderId) {
+    PreOrder preOrder = findPreOrderByPreOrderId(preOrderId);
+    preOrderRepository.delete(preOrder);
+  }
+
+  private PreOrder findPreOrderByPreOrderId(Long preOrderId) {
+    return preOrderRepository
+        .findByPreOrderIdAndIsPublicTrue(preOrderId)
+        .orElseThrow(() -> new ProductServerException(ProductErrorCode.NOT_FOUND_PREORDER));
+  }
+
+  private void validateStock(int nowQuantity, int requestStock) {
+    if (nowQuantity <= requestStock)
+      throw new ProductServerException(ProductErrorCode.PREORDER_QUANTITY_CONFLICT);
+  }
+
+  private Product getProductByProductId(UUID productId) {
+    return productRepository
+        .findByProductIdAndIsDeletedFalse(productId)
+        .orElseThrow(() -> new ProductServerException(ProductErrorCode.NOT_FOUND_PRODUCT));
+  }
+}

--- a/service/product/server/src/main/java/com/sparta/product/domain/model/PreOrder.java
+++ b/service/product/server/src/main/java/com/sparta/product/domain/model/PreOrder.java
@@ -1,0 +1,97 @@
+package com.sparta.product.domain.model;
+
+import com.sparta.common.domain.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "P_PREORDER")
+@NoArgsConstructor
+@Getter
+@SQLRestriction("is_deleted = false")
+@SQLDelete(sql = "UPDATE p_preorder SET is_deleted = true where preorder_id = ?")
+public class PreOrder extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "preorder_id")
+  private Long preOrderId;
+
+  @Column(nullable = false)
+  private UUID productId;
+
+  @Column(nullable = false)
+  private String preOrderTitle;
+
+  @Column(nullable = false)
+  private LocalDateTime startDateTime;
+
+  @Column(nullable = false)
+  private LocalDateTime endDateTime;
+
+  @Column(nullable = false)
+  private LocalDateTime releaseDateTime;
+
+  @Column
+  @Enumerated(EnumType.STRING)
+  private PreOrderState state = PreOrderState.INITIALIZED;
+
+  @Column(nullable = false)
+  private Integer availableQuantity;
+
+  @Column private boolean isPublic = true;
+
+  @Column private boolean isDeleted = false;
+
+  @Builder
+  private PreOrder(
+      UUID productId,
+      String preOrderTitle,
+      LocalDateTime startDateTime,
+      LocalDateTime endDateTime,
+      LocalDateTime releaseDateTime,
+      Integer availableQuantity) {
+    this.productId = productId;
+    this.preOrderTitle = preOrderTitle;
+    this.startDateTime = startDateTime;
+    this.endDateTime = endDateTime;
+    this.releaseDateTime = releaseDateTime;
+    this.availableQuantity = availableQuantity;
+  }
+
+  public void open() {
+    this.state = PreOrderState.OPEN_FOR_ORDER;
+  }
+
+  public void cancel() {
+    this.state = PreOrderState.CANCELLED;
+    this.isPublic = false;
+  }
+
+  public void update(
+      UUID productId,
+      String preOrderTitle,
+      LocalDateTime startDateTime,
+      LocalDateTime endDateTime,
+      LocalDateTime releaseDateTime,
+      Integer availableQuantity) {
+    this.productId = productId;
+    this.preOrderTitle = preOrderTitle;
+    this.startDateTime = startDateTime;
+    this.endDateTime = endDateTime;
+    this.releaseDateTime = releaseDateTime;
+    this.availableQuantity = availableQuantity;
+  }
+}

--- a/service/product/server/src/main/java/com/sparta/product/domain/model/PreOrderState.java
+++ b/service/product/server/src/main/java/com/sparta/product/domain/model/PreOrderState.java
@@ -1,0 +1,8 @@
+package com.sparta.product.domain.model;
+
+public enum PreOrderState {
+  INITIALIZED,
+  OPEN_FOR_ORDER,
+  CANCELLED,
+  COMPLETED
+}

--- a/service/product/server/src/main/java/com/sparta/product/domain/model/Product.java
+++ b/service/product/server/src/main/java/com/sparta/product/domain/model/Product.java
@@ -16,30 +16,30 @@ import org.springframework.data.domain.Persistable;
 @Getter
 public class Product extends BaseEntity implements Persistable {
   @PrimaryKey private UUID productId = UUID.randomUUID();
-  @Column public Long categoryId;
-  @Column public String productName;
-  @Column public String brandName;
-  @Column public String mainColor;
-  @Column public String size;
-  @Column public String description;
+  @Column private Long categoryId;
+  @Column private String productName;
+  @Column private String brandName;
+  @Column private String mainColor;
+  @Column private String size;
+  @Column private String description;
 
-  @Column public BigDecimal originalPrice;
-  @Column public BigDecimal discountedPrice;
-  @Column public Double discountPercent;
-  @Column public int stock;
+  @Column private BigDecimal originalPrice;
+  @Column private BigDecimal discountedPrice;
+  @Column private Double discountPercent;
+  @Column private int stock;
 
-  @Column public String thumbnailImgUrl;
-  @Column public String detailImgUrl;
+  @Column private String thumbnailImgUrl;
+  @Column private String detailImgUrl;
 
-  @Column public int limitCountPerUser = 0;
-  @Column public double averageRating = 0.0;
-  @Column public long reviewCount = 0;
-  @Column public long salesCount = 0;
+  @Column private int limitCountPerUser = 0;
+  @Column private double averageRating = 0.0;
+  @Column private long reviewCount = 0;
+  @Column private long salesCount = 0;
 
-  @Column public boolean isPublic = true;
-  @Column public boolean soldout = false;
-  @Column public boolean isDeleted = false;
-  @Column public List<String> tags;
+  @Column private boolean isPublic = true;
+  @Column private boolean soldout = false;
+  @Column private boolean isDeleted = false;
+  @Column private List<String> tags;
   @Transient private boolean isNew = false;
 
   @Override

--- a/service/product/server/src/main/java/com/sparta/product/domain/repository/jpa/PreOrderRepository.java
+++ b/service/product/server/src/main/java/com/sparta/product/domain/repository/jpa/PreOrderRepository.java
@@ -1,0 +1,15 @@
+package com.sparta.product.domain.repository.jpa;
+
+import com.sparta.product.domain.model.PreOrder;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PreOrderRepository extends JpaRepository<PreOrder, Long> {
+  Optional<PreOrder> findByPreOrderIdAndIsPublicTrue(Long preOrderId);
+
+  Page<PreOrder> findAllByIsPublicTrue(Pageable pageable);
+}

--- a/service/product/server/src/main/java/com/sparta/product/presentation/controller/PreOrderController.java
+++ b/service/product/server/src/main/java/com/sparta/product/presentation/controller/PreOrderController.java
@@ -1,0 +1,73 @@
+package com.sparta.product.presentation.controller;
+
+import com.sparta.common.domain.response.ApiResponse;
+import com.sparta.product.application.preorder.PreOrderService;
+import com.sparta.product.domain.model.PreOrderState;
+import com.sparta.product.presentation.request.PreOrderCreateRequest;
+import com.sparta.product.presentation.request.PreOrderUpdateRequest;
+import com.sparta.product.presentation.response.PreOrderResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/preorders")
+@RequiredArgsConstructor
+@Validated
+public class PreOrderController {
+  private final PreOrderService preOrderService;
+
+  @PostMapping
+  public ApiResponse<Long> createPreOrder(@RequestBody @Valid PreOrderCreateRequest request) {
+    return ApiResponse.created(preOrderService.createPreOrder(request));
+  }
+
+  @PatchMapping
+  public ApiResponse<PreOrderResponse> updatePreOrder(
+      @RequestBody @Valid PreOrderUpdateRequest request) {
+    return ApiResponse.ok(preOrderService.updatePreOrder(request));
+  }
+
+  @DeleteMapping("/{preOrderId}")
+  public ApiResponse<Void> deletePreOrder(@NotNull @PathVariable("preOrderId") Long preOrderId) {
+    preOrderService.deletePreOrder(preOrderId);
+    return ApiResponse.ok();
+  }
+
+  @PatchMapping("/{preOrderId}/open")
+  public ApiResponse<PreOrderResponse> openPreOrder(
+      @NotNull @PathVariable("preOrderId") Long preOrderId) {
+    return ApiResponse.ok(preOrderService.updateState(preOrderId, PreOrderState.OPEN_FOR_ORDER));
+  }
+
+  @PatchMapping("/{preOrderId}/cancel")
+  public ApiResponse<PreOrderResponse> cancelPreOrder(
+      @NotNull @PathVariable("preOrderId") Long preOrderId) {
+    return ApiResponse.ok(preOrderService.updateState(preOrderId, PreOrderState.CANCELLED));
+  }
+
+  @GetMapping("/{preOrderId}")
+  public ApiResponse<PreOrderResponse> getPreOrder(
+      @NotNull @PathVariable("preOrderId") Long preOrderId) {
+    return ApiResponse.ok(preOrderService.getPreOrder(preOrderId));
+  }
+
+  @GetMapping
+  public ApiResponse<Page<PreOrderResponse>> getPreOrderList(
+      @RequestParam(defaultValue = "0") @Min(0) int page,
+      @RequestParam(defaultValue = "30") @Min(1) int size) {
+    return ApiResponse.ok(preOrderService.getPreOrderList(page, size));
+  }
+}

--- a/service/product/server/src/main/java/com/sparta/product/presentation/exception/ProductErrorCode.java
+++ b/service/product/server/src/main/java/com/sparta/product/presentation/exception/ProductErrorCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ProductErrorCode {
   NOT_FOUND_PRODUCT(HttpStatus.NOT_FOUND, "상품이 존재하지 않습니다"),
   NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, "카테고리가 존재하지 않습니다"),
+  NOT_FOUND_PREORDER(HttpStatus.NOT_FOUND, "사전예약정보가 존재하지 않습니다"),
+  PREORDER_QUANTITY_CONFLICT(HttpStatus.CONFLICT, "예약가능수량이 재고량보다 많습니다"),
 
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류입니다");
 

--- a/service/product/server/src/main/java/com/sparta/product/presentation/request/PreOrderCreateRequest.java
+++ b/service/product/server/src/main/java/com/sparta/product/presentation/request/PreOrderCreateRequest.java
@@ -1,0 +1,14 @@
+package com.sparta.product.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record PreOrderCreateRequest(
+    @NotNull(message = "상품아이디는 필수입니다") UUID productId,
+    @NotBlank(message = "사전예약주문타이틀은 필수입니다") String preOrderTitle,
+    @NotNull(message = "사전예약시작일자는 필수입니다") LocalDateTime startDateTime,
+    @NotNull(message = "사전예약종료일자는 필수입니다") LocalDateTime endDateTime,
+    @NotNull(message = "사전예약발송일자는 필수입니다") LocalDateTime releaseDateTime,
+    @NotNull(message = "사전예약수량은 필수입니다") Integer availableQuantity) {}

--- a/service/product/server/src/main/java/com/sparta/product/presentation/request/PreOrderUpdateRequest.java
+++ b/service/product/server/src/main/java/com/sparta/product/presentation/request/PreOrderUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.sparta.product.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record PreOrderUpdateRequest(
+    @NotNull(message = "사전예약상품아이디는 필수입니다") Long preOrderId,
+    @NotNull(message = "상품아이디는 필수입니다") UUID productId,
+    @NotBlank(message = "사전예약주문타이틀은 필수입니다") String preOrderTitle,
+    @NotNull(message = "사전예약시작일자는 필수입니다") LocalDateTime startDateTime,
+    @NotNull(message = "사전예약종료일자는 필수입니다") LocalDateTime endDateTime,
+    @NotNull(message = "사전예약발송일자는 필수입니다") LocalDateTime releaseDateTime,
+    @NotNull(message = "사전예약수량은 필수입니다") Integer availableQuantity) {}

--- a/service/product/server/src/main/java/com/sparta/product/presentation/response/PreOrderResponse.java
+++ b/service/product/server/src/main/java/com/sparta/product/presentation/response/PreOrderResponse.java
@@ -1,0 +1,62 @@
+package com.sparta.product.presentation.response;
+
+import com.sparta.product.domain.model.PreOrder;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PreOrderResponse {
+  Long preOrderId;
+  UUID productId;
+  String preOrderTitle;
+  String state;
+  LocalDateTime startDateTime;
+  LocalDateTime endDateTime;
+  LocalDateTime releaseDateTime;
+  Integer availableQuantity;
+  boolean isPublic;
+  boolean isDeleted;
+
+  @Builder
+  private PreOrderResponse(
+      Long preOrderId,
+      UUID productId,
+      String preOrderTitle,
+      String state,
+      LocalDateTime startDateTime,
+      LocalDateTime endDateTime,
+      LocalDateTime releaseDateTime,
+      Integer availableQuantity,
+      boolean isPublic,
+      boolean isDeleted) {
+    this.preOrderId = preOrderId;
+    this.productId = productId;
+    this.preOrderTitle = preOrderTitle;
+    this.state = state;
+    this.startDateTime = startDateTime;
+    this.endDateTime = endDateTime;
+    this.releaseDateTime = releaseDateTime;
+    this.availableQuantity = availableQuantity;
+    this.isPublic = isPublic;
+    this.isDeleted = isDeleted;
+  }
+
+  public static PreOrderResponse of(PreOrder preOrder) {
+    return PreOrderResponse.builder()
+        .preOrderId(preOrder.getPreOrderId())
+        .productId(preOrder.getProductId())
+        .preOrderTitle(preOrder.getPreOrderTitle())
+        .state(preOrder.getState().name())
+        .startDateTime(preOrder.getStartDateTime())
+        .endDateTime(preOrder.getEndDateTime())
+        .releaseDateTime(preOrder.getReleaseDateTime())
+        .availableQuantity(preOrder.getAvailableQuantity())
+        .isPublic(preOrder.isPublic())
+        .isDeleted(preOrder.isDeleted())
+        .build();
+  }
+}


### PR DESCRIPTION
## 🎯 What is this PR

- 사전예약 등록 API
- 사전예약 수정 API
- 사전예약 오픈 API
- 사전예약 취소 API
- 사전예약 삭제 API
- 사전예약 단일조회 API
- 사전예약 목록조회 API

## 📄 Changes Made
- 사전예약 도메인 이름을 PREPRODUCT -> PREORDER로 지정, 게이트웨이 라우팅 엔드포인트 명도 변경
- 사전예약 등록/수정시 해당 productId가 존재해야하고, 현재 stock보다 적은 수량으로만 사전예약을 등록할 수 있음 
- 사전예약 상태는 초기엔 INITIALIZED, 오픈하면 OPEN_FOR_ORDER, 취소시 CANCELLED, 사전예약주문이 끝나면 COMPLETED로 바뀌게 됨 
- 사전예약 삭제는 soft delete처리 
- 자정이후 전날까지 사전예약주문이 열려있던 건들중 endTime이 오늘보다 작은건들의 상태를 COMPLETED로 바꾸는 로직 추가가 필요함 -> AWS Lambda/EventBridge 로 구축할 예정 
- TODO :: 사전예약 정보를 취소상태로 변경시 해당 주문건들이 있으면 해당 주문건도 취소처리 -> 해당 주문건의 결제건도 취소되는 상태전파가 필요함

## 🙋🏻‍ Review Point

## ✅ Test
> 사전예약정보 등록
<img width="664" alt="image" src="https://github.com/user-attachments/assets/a54484ac-5edc-423e-a339-da84e74d6a1e">


>사전예약정보 수정
<img width="636" alt="image" src="https://github.com/user-attachments/assets/3c34101a-96ec-4334-a215-61901d7218ce">
<img width="665" alt="image" src="https://github.com/user-attachments/assets/f8b5aacc-1eb2-4e34-8b11-5f67301dcb0c">


>사전예약정보 삭제
<img width="640" alt="image" src="https://github.com/user-attachments/assets/9288dc72-1729-41cd-a7b1-1ded79f3e4dd">


>사전예약 오픈
<img width="640" alt="image" src="https://github.com/user-attachments/assets/c95c9ded-f0d1-4c34-b4cb-b2445ef6fbce">


>사전예약 취소
<img width="663" alt="image" src="https://github.com/user-attachments/assets/af51b989-90bf-44d2-b4f8-05922de9243d">

## 🔗 Reference

Issue #96 