### PR TITLE
dev에 동시에 여러개가 merge 될 경우, 이전에 실행 중이던 dev 브랜치의 워크플로우가 취소

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -16,6 +16,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     permissions: write-all
     strategy:
       matrix:

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -12,13 +12,14 @@ permissions:
 env:
   ECR_NAMESPACE: sasaping
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.ref }}
-      cancel-in-progress: true
     permissions: write-all
     strategy:
       matrix:


### PR DESCRIPTION
## 🎯 What is this PR

- 동시에 여러개가 merge 될 경우, 깃 액션은 이걸 병렬로 처리한다. 병렬로 처리할 경우, 리소스 낭비며 배포 시 충동을 발생시킬 수 있다.

## 📄 Changes Made

- concurrency 옵션 추가

## 🔗 Reference

Issue #95 