### PR TITLE
(HOT)유저 엔티티에 이메일 컬럼 추가

### DIFF
--- a/service/user/server/src/main/java/com/sparta/user/application/service/UserService.java
+++ b/service/user/server/src/main/java/com/sparta/user/application/service/UserService.java
@@ -40,6 +40,7 @@ public class UserService {
         user.getId(),
         user.getUsername(),
         user.getPassword(),
+        user.getEmail(),
         user.getRole().name(),
         user.getPoint()
     );
@@ -54,6 +55,7 @@ public class UserService {
         user.getId(),
         user.getUsername(),
         user.getPassword(),
+        user.getEmail(),
         user.getRole().name(),
         user.getPoint()
     );

--- a/service/user/server/src/main/java/com/sparta/user/domain/model/User.java
+++ b/service/user/server/src/main/java/com/sparta/user/domain/model/User.java
@@ -43,6 +43,9 @@ public class User extends BaseEntity {
   @Column(nullable = false)
   private String nickname;
 
+  @Column(unique = true, nullable = false)
+  private String email;
+
   @Column(nullable = false)
   private BigDecimal point;
 
@@ -61,6 +64,7 @@ public class User extends BaseEntity {
         .username(request.getUsername())
         .password(encodedPassword)
         .nickname(request.getNickname())
+        .email(request.getEmail())
         .point(request.getPoint())
         .role(request.getRole())
         .build();

--- a/service/user/server/src/main/java/com/sparta/user/presentation/request/UserRequest.java
+++ b/service/user/server/src/main/java/com/sparta/user/presentation/request/UserRequest.java
@@ -2,6 +2,7 @@ package com.sparta.user.presentation.request;
 
 import com.sparta.user.domain.model.vo.UserRole;
 import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import java.math.BigDecimal;
@@ -25,6 +26,10 @@ public class UserRequest {
         message = "비밀번호는 8자 이상, 15자 이하의 알파벳 대소문자, 숫자 및 특수문자(_#$%^!-)만 허용됩니다.")
     @NotBlank(message = "비밀번호는 비어 있을 수 없습니다.")
     private String password;
+
+    @Email(message = "이메일 형식이 유효하지 않습니다.")
+    @NotBlank(message = "이메일은 비어 있을 수 없습니다.")
+    private String email;
 
     @NotBlank(message = "닉네임은 비어 있을 수 없습니다.")
     private String nickname;

--- a/service/user/server/src/test/java/com/sparta/user/http/UserApiTest.http
+++ b/service/user/server/src/test/java/com/sparta/user/http/UserApiTest.http
@@ -6,9 +6,10 @@ POST http://localhost:{{Port}}/api/users/sign-up
 Content-Type: application/json
 
 {
-  "username": "newUser",
+  "username": "newUser4",
   "password": "password123",
-  "nickname": "nickname",
+  "nickname": "nickname4",
+  "email": "newemail@email.com",
   "point": 0,
   "role": "관리자"
 }

--- a/service/user/server/src/test/java/com/sparta/user/service/AddressServiceTest.java
+++ b/service/user/server/src/test/java/com/sparta/user/service/AddressServiceTest.java
@@ -46,7 +46,7 @@ public class AddressServiceTest {
   void test_배송지_생성() {
     // given
     UserRequest.Create userRequest = new UserRequest.Create(
-        "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
+        "username", "password", "test@email.com", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
     );
     User user = User.create(userRequest, "encodedPassword");
 
@@ -96,7 +96,7 @@ public class AddressServiceTest {
   void test_배송지_단일_조회_성공() {
     // given
     UserRequest.Create userRequest = new UserRequest.Create(
-        "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
+        "username", "password", "test@email.com", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
     );
     User user = User.create(userRequest, "encodedPassword");
 
@@ -145,7 +145,7 @@ public class AddressServiceTest {
     // given
     Long userId = 1L;
     UserRequest.Create userRequest = new UserRequest.Create(
-        "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
+        "username", "password", "test@email.com", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
     );
     User user = User.create(userRequest, "encodedPassword");
 
@@ -183,7 +183,7 @@ public class AddressServiceTest {
   void test_전체_배송지_조회() {
     // given
     UserRequest.Create userRequest = new UserRequest.Create(
-        "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
+        "username", "password", "test@email.com", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
     );
     User user = User.create(userRequest, "encodedPassword");
 
@@ -221,7 +221,7 @@ public class AddressServiceTest {
     Long userId = 1L;
     Long addressId = 1L;
     UserRequest.Create userRequest = new UserRequest.Create(
-        "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
+        "username", "password", "test@email.com", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
     );
     User user = User.create(userRequest, "encodedPassword");
     Address address = Address.create(user, new AddressRequest.Create(
@@ -266,7 +266,7 @@ public class AddressServiceTest {
     Long addressId = 1L;
 
     UserRequest.Create userRequest = new UserRequest.Create(
-        "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
+        "username", "password", "test@email.com", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
     );
     User user = User.create(userRequest, "encodedPassword");
     Address address = Address.create(user, new AddressRequest.Create(

--- a/service/user/server/src/test/java/com/sparta/user/service/PointHistoryServiceTests.java
+++ b/service/user/server/src/test/java/com/sparta/user/service/PointHistoryServiceTests.java
@@ -40,7 +40,7 @@ public class PointHistoryServiceTests {
   void test_포인트_내역_추가_성공() {
     // Given
     UserRequest.Create userRequest = new UserRequest.Create(
-        "username", "password", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
+        "username", "password", "test@email.com", "nickname", BigDecimal.ZERO, UserRole.ROLE_USER
     );
     User user = User.create(userRequest, "encodedPassword");
     PointHistoryDto request = new PointHistoryDto(
@@ -53,6 +53,7 @@ public class PointHistoryServiceTests {
 
     // Mock user repository
     when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+    when(pointHistoryRepository.save(any(PointHistory.class))).thenReturn(new PointHistory());
 
     // When
     pointHistoryService.createPointHistory(request);
@@ -88,7 +89,8 @@ public class PointHistoryServiceTests {
   void test_포인트_내역_추가_시_유저의_포인트_부족() {
     // Given
     UserRequest.Create userRequest = new UserRequest.Create(
-        "username", "password", "nickname", new BigDecimal("100"), UserRole.ROLE_USER
+        "username", "password", "test@email.com", "nickname", new BigDecimal("100"),
+        UserRole.ROLE_USER
     );
     User user = User.create(userRequest, "encodedPassword");
     PointHistoryDto request = new PointHistoryDto(

--- a/service/user/server/src/test/java/com/sparta/user/service/UserServiceTests.java
+++ b/service/user/server/src/test/java/com/sparta/user/service/UserServiceTests.java
@@ -36,7 +36,8 @@ class UserServiceTests {
   void test_회원가입_시_존재하는_유저인지_확인() {
     // Arrange
     UserRequest.Create request =
-        new UserRequest.Create("existinguser", "password123", "nickname", BigDecimal.ZERO,
+        new UserRequest.Create("existinguser", "password123", "test@email.com", "nickname",
+            BigDecimal.ZERO,
             UserRole.ROLE_ADMIN);
 
     when(userRepository.findByUsername("existinguser")).thenReturn(Optional.of(new User()));
@@ -54,7 +55,8 @@ class UserServiceTests {
   void test_회원가입() {
     // Arrange
     UserRequest.Create request =
-        new UserRequest.Create("newuser", "password123", "nickname", BigDecimal.ZERO,
+        new UserRequest.Create("newuser", "password123", "test@email.com", "nickname",
+            BigDecimal.ZERO,
             UserRole.ROLE_ADMIN);
 
     when(userRepository.findByUsername("newuser")).thenReturn(Optional.empty());
@@ -77,6 +79,7 @@ class UserServiceTests {
     User savedUser = userCaptor.getValue();
     assertEquals("newuser", savedUser.getUsername());
     assertEquals("nickname", savedUser.getNickname());
+    assertEquals("test@email.com", savedUser.getEmail());
     assertEquals(BigDecimal.ZERO, savedUser.getPoint());
     assertEquals(UserRole.ROLE_ADMIN, savedUser.getRole());
   }
@@ -100,7 +103,8 @@ class UserServiceTests {
     // Arrange
     String username = "existinguser";
     UserRequest.Create request =
-        new UserRequest.Create(username, "password123", "nickname", BigDecimal.ZERO,
+        new UserRequest.Create(username, "password123", "nickname", "test@email.com",
+            BigDecimal.ZERO,
             UserRole.ROLE_ADMIN);
 
     User existingUser = User.create(request, "password123");

--- a/service/user/server/src/test/resources/application.yml
+++ b/service/user/server/src/test/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/user
+    username: user
+    password: password
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+
+eureka:
+  client:
+    enabled: false # 단위 테스트 시에는 유레카 클라이언트를 사용하지 않음

--- a/service/user/user_dto/src/main/java/com/sparta/user/user_dto/infrastructure/UserDto.java
+++ b/service/user/user_dto/src/main/java/com/sparta/user/user_dto/infrastructure/UserDto.java
@@ -13,6 +13,7 @@ public class UserDto {
   private Long userId;
   private String username;
   private String password;
+  private String email;
   private String role;
   private BigDecimal point;
 


### PR DESCRIPTION
## 🎯 What is this PR

- 주문 시 이메일을 넣어야하는데 주문 시 이메일을 매번 작성하는 것보다 유저에게 이메일 있는게 맞다.

## 📄 Changes Made

- 유저 엔티티에 이메일 컬럼 추가
- 이메일 추가에 따른 dto, test 수정

## ✅ Test

- [x] 유저 단위 테스트
![image](https://github.com/user-attachments/assets/041bd144-513b-4789-81dc-39b9e31e7a8e)

## 🔗 Reference

Issue #133 