### PR TITLE
사전예약 로직 수정

### DIFF
--- a/service/product/server/src/main/java/com/sparta/product/application/preorder/PreOrderCacheService.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/preorder/PreOrderCacheService.java
@@ -1,7 +1,10 @@
 package com.sparta.product.application.preorder;
 
 import com.sparta.product.domain.model.PreOrder;
+import com.sparta.product.domain.model.PreOrderState;
 import com.sparta.product.infrastructure.utils.PreOrderRedisDto;
+import com.sparta.product.presentation.exception.ProductErrorCode;
+import com.sparta.product.presentation.exception.ProductServerException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -14,6 +17,12 @@ public class PreOrderCacheService {
   @Cacheable(cacheNames = "preOrder", key = "#preOrderId")
   public PreOrderRedisDto getPreOrderCache(Long preOrderId) {
     PreOrder preOrder = preOrderService.findPreOrderByPreOrderId(preOrderId);
+    validatePreOrder(preOrder);
     return new PreOrderRedisDto(preOrder);
+  }
+
+  private void validatePreOrder(PreOrder preOrder) {
+    if (preOrder.getState() != PreOrderState.OPEN_FOR_ORDER)
+      throw new ProductServerException(ProductErrorCode.NOT_OPEN_FOR_PREORDER);
   }
 }

--- a/service/product/server/src/main/java/com/sparta/product/application/preorder/PreOrderFacadeService.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/preorder/PreOrderFacadeService.java
@@ -1,13 +1,9 @@
 package com.sparta.product.application.preorder;
 
 import com.sparta.common.domain.entity.KafkaTopicConstant;
-import com.sparta.product.domain.model.PreOrder;
-import com.sparta.product.domain.model.PreOrderState;
 import com.sparta.product.infrastructure.messaging.PreOrderProducer;
-import com.sparta.product.presentation.exception.ProductErrorCode;
-import com.sparta.product.presentation.exception.ProductServerException;
+import com.sparta.product.infrastructure.utils.PreOrderRedisDto;
 import dto.OrderCreateRequest;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,27 +11,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class PreOrderFacadeService {
-  private final PreOrderService preOrderService;
   private final PreOrderProducer preOrderProducer;
   private final PreOrderLockService preOrderLockService;
 
   @Transactional
   public void preOrder(Long preOrderId, Long addressId, Long userId) {
-    PreOrder preOrder = preOrderService.findPreOrderByPreOrderId(preOrderId);
-    preOrderLockService.reservation(preOrderId, userId);
-    OrderCreateRequest createRequest =
-        PreOrderMapper.toDto(preOrder.getProductId().toString(), addressId);
+    PreOrderRedisDto cachedData = preOrderLockService.reservation(preOrderId, userId);
+    OrderCreateRequest createRequest = PreOrderMapper.toDto(cachedData.productId(), addressId);
     preOrderProducer.send(
         KafkaTopicConstant.PROCESS_PREORDER, Long.toString(userId), createRequest);
-  }
-
-  private void validatePreOrder(PreOrder preOrder) {
-    if (preOrder.getState() != PreOrderState.OPEN_FOR_ORDER)
-      throw new ProductServerException(ProductErrorCode.NOT_OPEN_FOR_PREORDER);
-
-    LocalDateTime now = LocalDateTime.now();
-    if (now.isBefore(preOrder.getStartDateTime()) || now.isAfter(preOrder.getEndDateTime())) {
-      throw new ProductServerException(ProductErrorCode.CLOSED_PREORDER);
-    }
   }
 }

--- a/service/product/server/src/main/java/com/sparta/product/application/preorder/PreOrderLockService.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/preorder/PreOrderLockService.java
@@ -5,6 +5,7 @@ import static com.sparta.product.infrastructure.utils.RedisUtils.getRedisKeyOfPr
 import com.sparta.product.infrastructure.utils.PreOrderRedisDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -13,8 +14,9 @@ public class PreOrderLockService {
   private final PreOrderCacheService cacheService;
   private final DistributedLockComponent lockComponent;
 
+  @Transactional
   public PreOrderRedisDto reservation(long preOrderId, long userId) {
-    PreOrderRedisDto cachedPreOrder = cacheService.getPreOrderCache(preOrderId);
+    PreOrderRedisDto cachedPreOrder = cacheService.getPreOrderCache(preOrderId); // 오픈된 사전예약인지 검증
     cachedPreOrder.validateReservationDate(); // 사전예약기간인지 검증
     lockComponent.execute( // 락을 걸고
         "preOrderLock_%s".formatted(preOrderId),

--- a/service/product/server/src/main/java/com/sparta/product/application/preorder/PreOrderLockService.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/preorder/PreOrderLockService.java
@@ -13,7 +13,7 @@ public class PreOrderLockService {
   private final PreOrderCacheService cacheService;
   private final DistributedLockComponent lockComponent;
 
-  public void reservation(long preOrderId, long userId) {
+  public PreOrderRedisDto reservation(long preOrderId, long userId) {
     PreOrderRedisDto cachedPreOrder = cacheService.getPreOrderCache(preOrderId);
     cachedPreOrder.validateReservationDate(); // 사전예약기간인지 검증
     lockComponent.execute( // 락을 걸고
@@ -24,5 +24,6 @@ public class PreOrderLockService {
           redisService.validateQuantity(cachedPreOrder, userId); // 이미 예약에 성공한 유저인지, 수량안에 든 유저인지 검증
         });
     redisService.preOrder(getRedisKeyOfPreOrder(preOrderId), userId);
+    return cachedPreOrder;
   }
 }

--- a/service/product/server/src/main/java/com/sparta/product/application/preorder/PreOrderService.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/preorder/PreOrderService.java
@@ -13,6 +13,7 @@ import com.sparta.product.presentation.response.PreOrderResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -36,6 +37,7 @@ public class PreOrderService {
     return savedPreOrder.getPreOrderId();
   }
 
+  @CacheEvict(cacheNames = "preOrder", key = "#request.preOrderId()")
   public PreOrderResponse updatePreOrder(PreOrderUpdateRequest request) {
     PreOrder preOrder = findPreOrderByPreOrderId(request.preOrderId());
     if (preOrder.getProductId() != request.productId()) {
@@ -63,6 +65,7 @@ public class PreOrderService {
     return preOrderRepository.findAllByIsPublicTrue(pageable).map(PreOrderResponse::of);
   }
 
+  @CacheEvict(cacheNames = "preOrder", key = "#preOrderId")
   public PreOrderResponse updateState(Long preOrderId, PreOrderState state) {
     PreOrder preOrder = findPreOrderByPreOrderId(preOrderId);
     if (state == PreOrderState.OPEN_FOR_ORDER) preOrder.open();
@@ -70,11 +73,13 @@ public class PreOrderService {
     return PreOrderResponse.of(preOrder);
   }
 
+  @CacheEvict(cacheNames = "preOrder", key = "#preOrderId")
   public void deletePreOrder(Long preOrderId) {
     PreOrder preOrder = findPreOrderByPreOrderId(preOrderId);
     preOrderRepository.delete(preOrder);
   }
 
+  @Transactional(readOnly = true)
   public PreOrder findPreOrderByPreOrderId(Long preOrderId) {
     return preOrderRepository
         .findByPreOrderIdAndIsPublicTrue(preOrderId)

--- a/service/product/server/src/main/java/com/sparta/product/infrastructure/utils/PreOrderRedisDto.java
+++ b/service/product/server/src/main/java/com/sparta/product/infrastructure/utils/PreOrderRedisDto.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 
 public record PreOrderRedisDto(
     Long preOrderId,
+    String productId,
     Integer availableQuantity,
     @JsonSerialize(using = LocalDateTimeSerializer.class)
         @JsonDeserialize(using = LocalDateTimeDeserializer.class)
@@ -21,6 +22,7 @@ public record PreOrderRedisDto(
   public PreOrderRedisDto(PreOrder preOrder) {
     this(
         preOrder.getPreOrderId(),
+        preOrder.getProductId().toString(),
         preOrder.getAvailableQuantity(),
         preOrder.getStartDateTime(),
         preOrder.getEndDateTime());

--- a/service/product/server/src/main/java/com/sparta/product/infrastructure/utils/PreOrderRedisDto.java
+++ b/service/product/server/src/main/java/com/sparta/product/infrastructure/utils/PreOrderRedisDto.java
@@ -8,7 +8,9 @@ import com.sparta.product.domain.model.PreOrder;
 import com.sparta.product.presentation.exception.ProductErrorCode;
 import com.sparta.product.presentation.exception.ProductServerException;
 import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public record PreOrderRedisDto(
     Long preOrderId,
     String productId,


### PR DESCRIPTION
## 🎯 What is this PR
- 사전예약 로직에서 캐싱 부분 수정

## 📄 Changes Made
- 사전예약 캐싱정보에 productId를 저장하여 카프카에 productId를 보내는 것으로 수정함
- 사전예약 정보변경시(업데이트, 삭제, 오픈상태로변경) 사전예약 캐싱을 CacheEvict으로 삭제하는것으로 진행함
- 사전예약 정보 캐싱시 open된 사전예약건인지 검증하는 로직 추가
- Transacional 어노테이션들 붙이거나 삭제 

## 🙋🏻‍ Review Point

## ✅ Test

- [ ] 완료한 테스트 항목
> 사전예약주문하기 API
![image](https://github.com/user-attachments/assets/7dd99ceb-8612-45aa-9b78-dfd239c6fb4b)
![image](https://github.com/user-attachments/assets/e8dd489d-eedc-4a9d-8780-0ea249047065)

<img width="365" alt="image" src="https://github.com/user-attachments/assets/5f149d55-50bf-46b8-a891-5f45bc144aa9">


순서대로 API응답, kafka로 온 토픽정보 redis에 주문한유저관리

## 🔗 Reference
Issue #128 