### PR TITLE
fix(#91): S3 저장시 썸네일 이미지 경로도 함께 만들어서 저장

### DIFF
--- a/service/product/server/src/main/java/com/sparta/product/application/dto/ImgDto.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/dto/ImgDto.java
@@ -1,3 +1,3 @@
 package com.sparta.product.application.dto;
 
-public record ImgDto(String originImgUrl, String detailImgUrl) {}
+public record ImgDto(String originImgUrl, String detailImgUrl, String thumbnailImgUrl) {}

--- a/service/product/server/src/main/java/com/sparta/product/application/product/ProductMapper.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/product/ProductMapper.java
@@ -20,8 +20,7 @@ public class ProductMapper {
         .build();
   }
 
-  public static Product toEntity(
-      ProductCreateRequest request, String productImgUrl, String detailImgUrl) {
+  public static Product toEntity(ProductCreateRequest request, ImgDto imgDto) {
     return Product.builder()
         .categoryId(request.categoryId())
         .productName(request.productName())
@@ -31,8 +30,9 @@ public class ProductMapper {
         .description(request.description())
         .originalPrice(request.originalPrice())
         .discountPercent(request.discountPercent())
-        .originImgUrl(productImgUrl)
-        .detailImgUrl(detailImgUrl)
+        .originImgUrl(imgDto.originImgUrl())
+        .detailImgUrl(imgDto.detailImgUrl())
+        .thumbnailImgUrl(imgDto.thumbnailImgUrl())
         .stock(request.stock())
         .limitCountPerUser(request.limitCountPerUser())
         .tags(request.tags())
@@ -53,6 +53,7 @@ public class ProductMapper {
         request.description(),
         imgUrls.originImgUrl(),
         imgUrls.detailImgUrl(),
+        imgUrls.thumbnailImgUrl(),
         request.limitCountPerUser(),
         request.tags(),
         request.isPublic());

--- a/service/product/server/src/main/java/com/sparta/product/application/product/ProductService.java
+++ b/service/product/server/src/main/java/com/sparta/product/application/product/ProductService.java
@@ -34,9 +34,8 @@ public class ProductService {
   private final ProductRepository productRepository;
 
   @Transactional
-  public ProductResponse createProduct(
-      ProductCreateRequest request, String productImgUrl, String detailImgUrl) {
-    Product newProduct = ProductMapper.toEntity(request, productImgUrl, detailImgUrl);
+  public ProductResponse createProduct(ProductCreateRequest request, ImgDto imgDto) {
+    Product newProduct = ProductMapper.toEntity(request, imgDto);
     newProduct.setIsNew(true);
     Product savedProduct = productRepository.save(newProduct);
     return ProductResponse.fromEntity(savedProduct);
@@ -146,6 +145,5 @@ public class ProductService {
     if (product.getStock() < reduceCount) {
       throw new ProductServerException(ProductErrorCode.STOCK_NOT_AVAILABLE);
     }
-
   }
 }

--- a/service/product/server/src/main/java/com/sparta/product/domain/model/Product.java
+++ b/service/product/server/src/main/java/com/sparta/product/domain/model/Product.java
@@ -99,6 +99,7 @@ public class Product extends BaseEntity implements Persistable {
       String description,
       String originImgUrl,
       String detailImgUrl,
+      String thumbnailImgUrl,
       Integer limitCountPerUser,
       List<String> tags,
       boolean isPublic) {
@@ -114,6 +115,7 @@ public class Product extends BaseEntity implements Persistable {
     this.description = description;
     this.originImgUrl = originImgUrl;
     this.detailImgUrl = detailImgUrl;
+    this.thumbnailImgUrl = thumbnailImgUrl;
     this.tags = tags;
     this.limitCountPerUser = limitCountPerUser;
     this.isPublic = isPublic;


### PR DESCRIPTION
## 🎯 What is this PR
- s3 저장시 미리 썸네일 경로도 만들어서 db, elasticsearch에도 저장하도록 추가 

## 📄 Changes Made
- 추후 버킷을 하나로만 하고 폴더로 구분될 수 있게, 이미지 서버를 분리해서 리팩토링 해볼것 

## ✅ Test

> DB화면
<img width="961" alt="image" src="https://github.com/user-attachments/assets/62504b70-8837-4136-b8ae-7a568150b86f">


> 엘라스틱서치화면
<img width="1235" alt="image" src="https://github.com/user-attachments/assets/7b632629-e5bd-414a-a9b9-27e7673ee02f">


## 🔗 Reference

Issue #{이슈번호}