### PR TITLE
logback 프로필 분리 및 s3Client 빈 설정 추가 

### DIFF
--- a/service/product/server/src/main/java/com/sparta/product/infrastructure/configuration/S3Config.java
+++ b/service/product/server/src/main/java/com/sparta/product/infrastructure/configuration/S3Config.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 @Configuration
 public class S3Config {
@@ -21,6 +22,7 @@ public class S3Config {
   public String s3Region;
 
   @Bean
+  @Lazy
   public AmazonS3 s3Client() {
     BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
     return AmazonS3ClientBuilder.standard()

--- a/service/product/server/src/main/resources/logback-spring.xml
+++ b/service/product/server/src/main/resources/logback-spring.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<configuration scan="true" scanPeriod="30 seconds">
+<configuration>
+
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
       <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} springboot-elk [%thread] %-5level %logger{36} - %msg%n
@@ -7,28 +7,35 @@
     </encoder>
   </appender>
 
-  <!-- Logstash로 로그 전송 -->
-  <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-    <param name="Encoding" value="UTF-8"/>
-    <destination>logstash01:50000</destination>
+  <!-- Logstash appender는 prod 프로파일에서만 사용 -->
+  <springProfile name="prod">
+    <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+      <param name="Encoding" value="UTF-8"/>
+      <destination>127.0.0.1:50000</destination>
+      <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+        <providers>
+          <timestamp>
+            <timeZone>UTC</timeZone>
+          </timestamp>
+          <logLevel/>
+          <threadName/>
+          <loggerName/>
+          <message/>
+          <stackTrace/>
+        </providers>
+      </encoder>
+    </appender>
+    <root level="INFO">
+      <appender-ref ref="CONSOLE"/>
+      <appender-ref ref="LOGSTASH"/>
+    </root>
+  </springProfile>
 
-    <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-      <providers>
-        <timestamp>
-          <timeZone>UTC</timeZone>
-        </timestamp>
-        <logLevel/>
-        <threadName/>
-        <loggerName/>
-        <message/>
-        <stackTrace/>
-      </providers>
-    </encoder>
-  </appender>
-
-  <root level="INFO">
-    <appender-ref ref="CONSOLE"/>
-    <appender-ref ref="LOGSTASH"/>
-  </root>
+  <!-- prod가 아닌 환경에서는 CONSOLE appender만 사용 -->
+  <springProfile name="!prod">
+    <root level="INFO">
+      <appender-ref ref="CONSOLE"/>
+    </root>
+  </springProfile>
 
 </configuration>

--- a/service/user/server/build.gradle
+++ b/service/user/server/build.gradle
@@ -45,8 +45,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
-
+    //implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
 }
 
 dependencyManagement {


### PR DESCRIPTION
## 🎯 What is this PR
- local 프로파일에서 서버 띄울때 적용해야할 것들 

## 📄 Changes Made
- logback 설정이 prod에서만 활성화되도록 수정 
- logstash 의존성 주석처리 (제거x)
- s3Client 빈이 주입되는 시점에 띄워지도록 수정 

## 🙋🏻‍ Review Point
- build.gradle, logback-spring.xml 참고해서 수정해주시면 됩니다 
- S3 연결은 버킷이 아닌 유저에 연결하는거라서 그냥 냅두시면 됩니다 

## ✅ Test
> 해당 내용으로 서버띄울시에 정상 수행되는것을 확인
<img width="846" alt="image" src="https://github.com/user-attachments/assets/809bdf2c-cb2c-448f-8496-5b748ea897ee">